### PR TITLE
Repeat line number to be resilient to trim

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,7 +51,7 @@ func (n *nodeError) Error() string {
 			tailLen = 1
 		}
 		marker := strings.Repeat(" ", n.Node.Column-1) + "^" + strings.Repeat(".", tailLen)
-		result.WriteString(fmt.Sprintf("%s | %s %s\n", strings.Repeat(" ", len(lineNum)), marker, n.Unwrap().Error()))
+		result.WriteString(fmt.Sprintf("%s | %s %s\n", lineNum, marker, n.Unwrap().Error()))
 	}
 	return result.String()
 }

--- a/internal/cmd/generate-txt-testdata/main.go
+++ b/internal/cmd/generate-txt-testdata/main.go
@@ -52,7 +52,7 @@ func run() error {
 				return err
 			}
 			if !strings.HasSuffix(path, ".yaml") {
-				return fmt.Errorf("expected .yaml file, got %v", path)
+				return nil
 			}
 			actualText, err := tryParse(path)
 			if err != nil {

--- a/internal/testdata/basic.proto3test.txt
+++ b/internal/testdata/basic.proto3test.txt
@@ -1,235 +1,235 @@
 internal/testdata/basic.proto3test.yaml:5:18 expected bool, got "1"
    5 |   - single_bool: 1
-     |                  ^...................... expected bool, got "1"
+   5 |                  ^...................... expected bool, got "1"
 
 internal/testdata/basic.proto3test.yaml:6:18 expected bool, got "0"
    6 |   - single_bool: 0
-     |                  ^...................... expected bool, got "0"
+   6 |                  ^...................... expected bool, got "0"
 
 internal/testdata/basic.proto3test.yaml:7:18 expected tag !!bool, got !!str
    7 |   - single_bool: "true"
-     |                  ^...................... expected tag !!bool, got !!str
+   7 |                  ^...................... expected tag !!bool, got !!str
 
 internal/testdata/basic.proto3test.yaml:8:18 expected tag !!bool, got !!str
    8 |   - single_bool: "false"
-     |                  ^...................... expected tag !!bool, got !!str
+   8 |                  ^...................... expected tag !!bool, got !!str
 
 internal/testdata/basic.proto3test.yaml:9:18 expected bool, got "True"
    9 |   - single_bool: True
-     |                  ^...................... expected bool, got "True"
+   9 |                  ^...................... expected bool, got "True"
 
 internal/testdata/basic.proto3test.yaml:10:18 expected bool, got "False"
   10 |   - single_bool: False
-     |                  ^...................... expected bool, got "False"
+  10 |                  ^...................... expected bool, got "False"
 
 internal/testdata/basic.proto3test.yaml:11:18 expected bool, got "TRUE"
   11 |   - single_bool: TRUE
-     |                  ^...................... expected bool, got "TRUE"
+  11 |                  ^...................... expected bool, got "TRUE"
 
 internal/testdata/basic.proto3test.yaml:12:18 expected bool, got "FALSE"
   12 |   - single_bool: FALSE
-     |                  ^...................... expected bool, got "FALSE"
+  12 |                  ^...................... expected bool, got "FALSE"
 
 internal/testdata/basic.proto3test.yaml:13:18 expected bool, got "yes"
   13 |   - single_bool: yes
-     |                  ^...................... expected bool, got "yes"
+  13 |                  ^...................... expected bool, got "yes"
 
 internal/testdata/basic.proto3test.yaml:14:18 expected bool, got "no"
   14 |   - single_bool: no
-     |                  ^...................... expected bool, got "no"
+  14 |                  ^...................... expected bool, got "no"
 
 internal/testdata/basic.proto3test.yaml:15:18 expected scalar, got sequence
   15 |   - single_bool: []
-     |                  ^...................... expected scalar, got sequence
+  15 |                  ^...................... expected scalar, got sequence
 
 internal/testdata/basic.proto3test.yaml:16:18 expected scalar, got mapping
   16 |   - single_bool: {}
-     |                  ^...................... expected scalar, got mapping
+  16 |                  ^...................... expected scalar, got mapping
 
 internal/testdata/basic.proto3test.yaml:23:19 integer is too large: > 2147483647
   23 |   - single_int32: 2147483648
-     |                   ^..................... integer is too large: > 2147483647
+  23 |                   ^..................... integer is too large: > 2147483647
 
 internal/testdata/basic.proto3test.yaml:24:19 integer is too small: < -2147483648
   24 |   - single_int32: -2147483649
-     |                   ^..................... integer is too small: < -2147483648
+  24 |                   ^..................... integer is too small: < -2147483648
 
 internal/testdata/basic.proto3test.yaml:27:19 integer is too large: > 2147483647
   27 |   - single_int32: 0X80000000
-     |                   ^..................... integer is too large: > 2147483647
+  27 |                   ^..................... integer is too large: > 2147483647
 
 internal/testdata/basic.proto3test.yaml:28:19 integer is too small: < -2147483648
   28 |   - single_int32: -0x80000001
-     |                   ^..................... integer is too small: < -2147483648
+  28 |                   ^..................... integer is too small: < -2147483648
 
 internal/testdata/basic.proto3test.yaml:31:19 integer is too large: > 2147483647
   31 |   - single_int32: 0O20000000000
-     |                   ^..................... integer is too large: > 2147483647
+  31 |                   ^..................... integer is too large: > 2147483647
 
 internal/testdata/basic.proto3test.yaml:32:19 integer is too small: < -2147483648
   32 |   - single_int32: -0o20000000001
-     |                   ^..................... integer is too small: < -2147483648
+  32 |                   ^..................... integer is too small: < -2147483648
 
 internal/testdata/basic.proto3test.yaml:35:19 integer is too large: > 2147483647
   35 |   - single_int32: 0B10000000000000000000000000000000
-     |                   ^................................. integer is too large: > 2147483647
+  35 |                   ^................................. integer is too large: > 2147483647
 
 internal/testdata/basic.proto3test.yaml:36:19 integer is too small: < -2147483648
   36 |   - single_int32: -0b10000000000000000000000000000001
-     |                   ^.................................. integer is too small: < -2147483648
+  36 |                   ^.................................. integer is too small: < -2147483648
 
 internal/testdata/basic.proto3test.yaml:37:19 invalid integer: precision loss
   37 |   - single_int32: 1.5
-     |                   ^..................... invalid integer: precision loss
+  37 |                   ^..................... invalid integer: precision loss
 
 internal/testdata/basic.proto3test.yaml:40:19 invalid integer: precision loss
   40 |   - single_int32: 5.0e-1
-     |                   ^..................... invalid integer: precision loss
+  40 |                   ^..................... invalid integer: precision loss
 
 internal/testdata/basic.proto3test.yaml:46:19 integer is too large: > 9223372036854775807
   46 |   - single_int64: 9223372036854775808
-     |                   ^..................... integer is too large: > 9223372036854775807
+  46 |                   ^..................... integer is too large: > 9223372036854775807
 
 internal/testdata/basic.proto3test.yaml:47:19 integer is too small: < -9223372036854775808
   47 |   - single_int64: -9223372036854775809
-     |                   ^..................... integer is too small: < -9223372036854775808
+  47 |                   ^..................... integer is too small: < -9223372036854775808
 
 internal/testdata/basic.proto3test.yaml:49:19 invalid integer: precision loss
   49 |   - single_int64: 9007199254740992.0
-     |                   ^..................... invalid integer: precision loss
+  49 |                   ^..................... invalid integer: precision loss
 
 internal/testdata/basic.proto3test.yaml:50:19 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
   50 |   - single_int32: --1
-     |                   ^..................... invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
+  50 |                   ^..................... invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:51:19 invalid integer: strconv.ParseUint: parsing "--1": invalid syntax
   51 |   - single_int32: ---1
-     |                   ^..................... invalid integer: strconv.ParseUint: parsing "--1": invalid syntax
+  51 |                   ^..................... invalid integer: strconv.ParseUint: parsing "--1": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:52:19 invalid integer: precision loss
   52 |   - single_int32: inf
-     |                   ^..................... invalid integer: precision loss
+  52 |                   ^..................... invalid integer: precision loss
 
 internal/testdata/basic.proto3test.yaml:52:19 integer is too large: > 2147483647
   52 |   - single_int32: inf
-     |                   ^..................... integer is too large: > 2147483647
+  52 |                   ^..................... integer is too large: > 2147483647
 
 internal/testdata/basic.proto3test.yaml:53:19 invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
   53 |   - single_int32: .inf
-     |                   ^..................... invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
+  53 |                   ^..................... invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:54:19 invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
   54 |   - single_int32: -.inf
-     |                   ^..................... invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
+  54 |                   ^..................... invalid integer: strconv.ParseUint: parsing ".inf": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:55:19 invalid integer: strconv.ParseUint: parsing ".nan": invalid syntax
   55 |   - single_int32: .nan
-     |                   ^..................... invalid integer: strconv.ParseUint: parsing ".nan": invalid syntax
+  55 |                   ^..................... invalid integer: strconv.ParseUint: parsing ".nan": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:56:20 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
   56 |   - single_uint32: -1
-     |                    ^.................... invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
+  56 |                    ^.................... invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:61:20 integer is too large: > 4294967295
   61 |   - single_uint32: 4294967296
-     |                    ^.................... integer is too large: > 4294967295
+  61 |                    ^.................... integer is too large: > 4294967295
 
 internal/testdata/basic.proto3test.yaml:63:20 invalid integer: precision loss
   63 |   - single_uint64: 18446744073709551616
-     |                    ^.................... invalid integer: precision loss
+  63 |                    ^.................... invalid integer: precision loss
 
 internal/testdata/basic.proto3test.yaml:69:19 invalid float: strconv.ParseFloat: parsing "1.7014118346046923e+39": value out of range
   69 |   - single_float: 1.7014118346046923e+39
-     |                   ^..................... invalid float: strconv.ParseFloat: parsing "1.7014118346046923e+39": value out of range
+  69 |                   ^..................... invalid float: strconv.ParseFloat: parsing "1.7014118346046923e+39": value out of range
 
 internal/testdata/basic.proto3test.yaml:81:20 expected scalar, got sequence
   81 |   - single_string: []
-     |                    ^.................... expected scalar, got sequence
+  81 |                    ^.................... expected scalar, got sequence
 
 internal/testdata/basic.proto3test.yaml:82:20 expected scalar, got mapping
   82 |   - single_string: {}
-     |                    ^.................... expected scalar, got mapping
+  82 |                    ^.................... expected scalar, got mapping
 
 internal/testdata/basic.proto3test.yaml:85:19 invalid base64: illegal base64 data at input byte 3
   85 |   - single_bytes: bad base64
-     |                   ^..................... invalid base64: illegal base64 data at input byte 3
+  85 |                   ^..................... invalid base64: illegal base64 data at input byte 3
 
 internal/testdata/basic.proto3test.yaml:93:22 unknown enum value "UNKNOWN", expected one of [FOO BAR BAZ]
   93 |   - standalone_enum: UNKNOWN
-     |                      ^.................. unknown enum value "UNKNOWN", expected one of [FOO BAR BAZ]
+  93 |                      ^.................. unknown enum value "UNKNOWN", expected one of [FOO BAR BAZ]
 
 internal/testdata/basic.proto3test.yaml:95:22 unknown enum value "foo", expected one of [FOO BAR BAZ]
   95 |   - standalone_enum: foo
-     |                      ^.................. unknown enum value "foo", expected one of [FOO BAR BAZ]
+  95 |                      ^.................. unknown enum value "foo", expected one of [FOO BAR BAZ]
 
 internal/testdata/basic.proto3test.yaml:96:21 expected sequence, got scalar
   96 |   - repeated_int32: 1
-     |                     ^................... expected sequence, got scalar
+  96 |                     ^................... expected sequence, got scalar
 
 internal/testdata/basic.proto3test.yaml:98:30 invalid integer: strconv.ParseUint: parsing "hi": invalid syntax
   98 |   - repeated_int32: [1, "1", hi]
-     |                              ^.......... invalid integer: strconv.ParseUint: parsing "hi": invalid syntax
+  98 |                              ^.......... invalid integer: strconv.ParseUint: parsing "hi": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:99:21 expected sequence, got mapping
   99 |   - repeated_int32: {}
-     |                     ^................... expected sequence, got mapping
+  99 |                     ^................... expected sequence, got mapping
 
 internal/testdata/basic.proto3test.yaml:100:22 expected scalar, got sequence
  100 |   - repeated_int32: [[]]
-     |                      ^.................. expected scalar, got sequence
+ 100 |                      ^.................. expected scalar, got sequence
 
 internal/testdata/basic.proto3test.yaml:101:22 expected scalar, got sequence
  101 |   - repeated_int32: [[1]]
-     |                      ^.................. expected scalar, got sequence
+ 101 |                      ^.................. expected scalar, got sequence
 
 internal/testdata/basic.proto3test.yaml:102:25 expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got scalar
  102 |   - standalone_message: 1
-     |                         ^............... expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got scalar
+ 102 |                         ^............... expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got scalar
 
 internal/testdata/basic.proto3test.yaml:103:25 expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got sequence
  103 |   - standalone_message: []
-     |                         ^............... expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got sequence
+ 103 |                         ^............... expected fields for bufext.cel.expr.conformance.proto3.TestAllTypes.NestedMessage, got sequence
 
 internal/testdata/basic.proto3test.yaml:105:22 invalid duration: missing trailing 's'
  105 |   - single_duration: 1
-     |                      ^.................. invalid duration: missing trailing 's'
+ 105 |                      ^.................. invalid duration: missing trailing 's'
 
 internal/testdata/basic.proto3test.yaml:108:22 invalid duration: too many fractional second digits
  108 |   - single_duration: 1.0123456789s
-     |                      ^.................. invalid duration: too many fractional second digits
+ 108 |                      ^.................. invalid duration: too many fractional second digits
 
 internal/testdata/basic.proto3test.yaml:109:22 invalid duration: strconv.ParseInt: parsing "A": invalid syntax
  109 |   - single_duration: As
-     |                      ^.................. invalid duration: strconv.ParseInt: parsing "A": invalid syntax
+ 109 |                      ^.................. invalid duration: strconv.ParseInt: parsing "A": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:110:22 invalid duration: strconv.ParseInt: parsing "A": invalid syntax
  110 |   - single_duration: A.1s
-     |                      ^.................. invalid duration: strconv.ParseInt: parsing "A": invalid syntax
+ 110 |                      ^.................. invalid duration: strconv.ParseInt: parsing "A": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:111:22 invalid duration: invalid duration: too many '.' characters
  111 |   - single_duration: 1.1.1s
-     |                      ^.................. invalid duration: invalid duration: too many '.' characters
+ 111 |                      ^.................. invalid duration: invalid duration: too many '.' characters
 
 internal/testdata/basic.proto3test.yaml:112:22 invalid duration: strconv.ParseInt: parsing "B": invalid syntax
  112 |   - single_duration: 1.Bs
-     |                      ^.................. invalid duration: strconv.ParseInt: parsing "B": invalid syntax
+ 112 |                      ^.................. invalid duration: strconv.ParseInt: parsing "B": invalid syntax
 
 internal/testdata/basic.proto3test.yaml:117:23 invalid timestamp: before 0001-01-01T00:00:00Z
  117 |   - single_timestamp: 0000-01-01T00:00:00Z
-     |                       ^................... invalid timestamp: before 0001-01-01T00:00:00Z
+ 117 |                       ^................... invalid timestamp: before 0001-01-01T00:00:00Z
 
 internal/testdata/basic.proto3test.yaml:119:23 invalid timestamp: parsing time "9999-12-31T23:59:60Z": second out of range
  119 |   - single_timestamp: 9999-12-31T23:59:60Z
-     |                       ^................... invalid timestamp: parsing time "9999-12-31T23:59:60Z": second out of range
+ 119 |                       ^................... invalid timestamp: parsing time "9999-12-31T23:59:60Z": second out of range
 
 internal/testdata/basic.proto3test.yaml:123:23 invalid timestamp: parsing time "10" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "10" as "2006"
  123 |   - single_timestamp: 10
-     |                       ^................. invalid timestamp: parsing time "10" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "10" as "2006"
+ 123 |                       ^................. invalid timestamp: parsing time "10" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "10" as "2006"
 
 internal/testdata/basic.proto3test.yaml:124:23 invalid timestamp: parsing time "hello" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "hello" as "2006"
  124 |   - single_timestamp: hello
-     |                       ^................. invalid timestamp: parsing time "hello" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "hello" as "2006"
+ 124 |                       ^................. invalid timestamp: parsing time "hello" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "hello" as "2006"
 
 internal/testdata/basic.proto3test.yaml:128:23 expected fields for google.protobuf.Timestamp, got sequence
  128 |   - single_timestamp: []
-     |                       ^................. expected fields for google.protobuf.Timestamp, got sequence
+ 128 |                       ^................. expected fields for google.protobuf.Timestamp, got sequence

--- a/internal/testdata/dynamic.const.txt
+++ b/internal/testdata/dynamic.const.txt
@@ -1,167 +1,167 @@
 internal/testdata/dynamic.const.yaml:10:12 expected boolean for google.protobuf.BoolValue.value, got sequence
   10 |     value: []
-     |            ^............................ expected boolean for google.protobuf.BoolValue.value, got sequence
+  10 |            ^............................ expected boolean for google.protobuf.BoolValue.value, got sequence
 
 internal/testdata/dynamic.const.yaml:13:12 expected boolean for google.protobuf.BoolValue.value, got mapping
   13 |     value: {}
-     |            ^............................ expected boolean for google.protobuf.BoolValue.value, got mapping
+  13 |            ^............................ expected boolean for google.protobuf.BoolValue.value, got mapping
 
 internal/testdata/dynamic.const.yaml:16:12 expected boolean for google.protobuf.BoolValue.value, got null
   16 |     value: null
-     |            ^............................ expected boolean for google.protobuf.BoolValue.value, got null
+  16 |            ^............................ expected boolean for google.protobuf.BoolValue.value, got null
 
 internal/testdata/dynamic.const.yaml:19:12 expected int32 for google.protobuf.Int32Value.value, got bool
   19 |     value: true
-     |            ^............................ expected int32 for google.protobuf.Int32Value.value, got bool
+  19 |            ^............................ expected int32 for google.protobuf.Int32Value.value, got bool
 
 internal/testdata/dynamic.const.yaml:31:12 expected scalar for google.protobuf.StringValue.value, got sequence
   31 |     value: []
-     |            ^............................ expected scalar for google.protobuf.StringValue.value, got sequence
+  31 |            ^............................ expected scalar for google.protobuf.StringValue.value, got sequence
 
 internal/testdata/dynamic.const.yaml:37:26 expected tag !!bool, got !!str
   37 |     single_bool_wrapper: "true"
-     |                          ^.............. expected tag !!bool, got !!str
+  37 |                          ^.............. expected tag !!bool, got !!str
 
 internal/testdata/dynamic.const.yaml:40:21 expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got scalar
   40 |     repeated_int32: 1
-     |                     ^................... expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got scalar
+  40 |                     ^................... expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got scalar
 
 internal/testdata/dynamic.const.yaml:43:21 expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got mapping
   43 |     repeated_int32: {}
-     |                     ^................... expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got mapping
+  43 |                     ^................... expected sequence for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got mapping
 
 internal/testdata/dynamic.const.yaml:46:30 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
   46 |     repeated_int32: [1, "1", 1.5, hi, Infinity, NaN]
-     |                              ^...................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
+  46 |                              ^...................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
 
 internal/testdata/dynamic.const.yaml:46:35 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got string
   46 |     repeated_int32: [1, "1", 1.5, hi, Infinity, NaN]
-     |                                   ^................. expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got string
+  46 |                                   ^................. expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got string
 
 internal/testdata/dynamic.const.yaml:46:39 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
   46 |     repeated_int32: [1, "1", 1.5, hi, Infinity, NaN]
-     |                                       ^............. expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
+  46 |                                       ^............. expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
 
 internal/testdata/dynamic.const.yaml:46:49 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
   46 |     repeated_int32: [1, "1", 1.5, hi, Infinity, NaN]
-     |                                                 ^... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
+  46 |                                                 ^... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got float
 
 internal/testdata/dynamic.const.yaml:49:35 expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got string
   49 |     repeated_float: [1, "1", 1.5, hi, Infinity, NaN, 16777215, 16777216, 16777217]
-     |                                   ^............................................... expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got string
+  49 |                                   ^............................................... expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got string
 
 internal/testdata/dynamic.const.yaml:49:74 expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
   49 |     repeated_float: [1, "1", 1.5, hi, Infinity, NaN, 16777215, 16777216, 16777217]
-     |                                                                          ^........ expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
+  49 |                                                                          ^........ expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
 
 internal/testdata/dynamic.const.yaml:52:36 expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got string
   52 |     repeated_double: [1, "1", 1.5, hi, Infinity, NaN, 9007199254740991, 9007199254740992, 9007199254740993]
-     |                                    ^....................................................................... expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got string
+  52 |                                    ^....................................................................... expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got string
 
 internal/testdata/dynamic.const.yaml:52:91 expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer
   52 |     repeated_double: [1, "1", 1.5, hi, Infinity, NaN, 9007199254740991, 9007199254740992, 9007199254740993]
-     |                                                                                           ^................ expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer
+  52 |                                                                                           ^................ expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer
 
 internal/testdata/dynamic.const.yaml:55:22 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                      ^......................................................... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
+  55 |                      ^......................................................... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
 
 internal/testdata/dynamic.const.yaml:55:25 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                         ^...................................................... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
+  55 |                         ^...................................................... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
 
 internal/testdata/dynamic.const.yaml:55:30 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 1
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                              ^................................................. expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 1
+  55 |                              ^................................................. expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 1
 
 internal/testdata/dynamic.const.yaml:55:35 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                                   ^............................................ expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
+  55 |                                   ^............................................ expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
 
 internal/testdata/dynamic.const.yaml:55:49 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                                                 ^.............................. expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
+  55 |                                                 ^.............................. expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 0
 
 internal/testdata/dynamic.const.yaml:55:68 expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 4
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
-     |                                                                    ^........... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 4
+  55 |                                                                    ^........... expected base64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_bytes, but illegal base64 data at input byte 4
 
 internal/testdata/dynamic.const.yaml:66:12 expected boolean for google.protobuf.BoolValue.value, got string
   66 |     value: True
-     |            ^............................ expected boolean for google.protobuf.BoolValue.value, got string
+  66 |            ^............................ expected boolean for google.protobuf.BoolValue.value, got string
 
 internal/testdata/dynamic.const.yaml:70:7 expected scalar, got sequence
   70 |       []: true
-     |       ^................................. expected scalar, got sequence
+  70 |       ^................................. expected scalar, got sequence
 
 internal/testdata/dynamic.const.yaml:71:7 expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.key, got number
   71 |       1: true
-     |       ^................................. expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.key, got number
+  71 |       ^................................. expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.key, got number
 
 internal/testdata/dynamic.const.yaml:72:13 expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.value, got number
   72 |       true: 1
-     |             ^........................... expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.value, got number
+  72 |             ^........................... expected boolean for bufext.cel.expr.conformance.proto3.TestAllTypes.MapBoolBoolEntry.value, got number
 
 internal/testdata/dynamic.const.yaml:77:14 expected boolean for google.protobuf.BoolValue.value, got string
   77 |       value: hi
-     |              ^.......................... expected boolean for google.protobuf.BoolValue.value, got string
+  77 |              ^.......................... expected boolean for google.protobuf.BoolValue.value, got string
 
 internal/testdata/dynamic.const.yaml:80:22 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
   80 |     repeated_int32: [1.5, -2147483648, -2147483649, 2147483647, 2147483648]
-     |                      ^..................................................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
+  80 |                      ^..................................................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, but: precision loss
 
 internal/testdata/dynamic.const.yaml:80:40 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
   80 |     repeated_int32: [1.5, -2147483648, -2147483649, 2147483647, 2147483648]
-     |                                        ^................................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
+  80 |                                        ^................................... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
 
 internal/testdata/dynamic.const.yaml:80:65 expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
   80 |     repeated_int32: [1.5, -2147483648, -2147483649, 2147483647, 2147483648]
-     |                                                                 ^.......... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
+  80 |                                                                 ^.......... expected int32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int32, got int64
 
 internal/testdata/dynamic.const.yaml:81:22 expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: precision loss
   81 |     repeated_int64: [1.5, -9223372036854775808, -9223372036854775809, 9223372036854775807, 9223372036854775808]
-     |                      ^......................................................................................... expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: precision loss
+  81 |                      ^......................................................................................... expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: precision loss
 
 internal/testdata/dynamic.const.yaml:81:49 expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: out of range
   81 |     repeated_int64: [1.5, -9223372036854775808, -9223372036854775809, 9223372036854775807, 9223372036854775808]
-     |                                                 ^.............................................................. expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: out of range
+  81 |                                                 ^.............................................................. expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, but: out of range
 
 internal/testdata/dynamic.const.yaml:81:92 expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, got uint64
   81 |     repeated_int64: [1.5, -9223372036854775808, -9223372036854775809, 9223372036854775807, 9223372036854775808]
-     |                                                                                            ^................... expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, got uint64
+  81 |                                                                                            ^................... expected int64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_int64, got uint64
 
 internal/testdata/dynamic.const.yaml:82:23 expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, but: precision loss
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
-     |                       ^.................................. expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, but: precision loss
+  82 |                       ^.................................. expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, but: precision loss
 
 internal/testdata/dynamic.const.yaml:82:28 expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got negative
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
-     |                            ^............................. expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got negative
+  82 |                            ^............................. expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got negative
 
 internal/testdata/dynamic.const.yaml:82:47 expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got uint64
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
-     |                                               ^.......... expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got uint64
+  82 |                                               ^.......... expected uint32 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint32, got uint64
 
 internal/testdata/dynamic.const.yaml:83:23 expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
-     |                       ^...................................................... expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
+  83 |                       ^...................................................... expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
 
 internal/testdata/dynamic.const.yaml:83:28 expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, got negative
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
-     |                            ^................................................. expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, got negative
+  83 |                            ^................................................. expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, got negative
 
 internal/testdata/dynamic.const.yaml:83:57 expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
-     |                                                         ^.................... expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
+  83 |                                                         ^.................... expected uint64 for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_uint64, but: precision loss
 
 internal/testdata/dynamic.const.yaml:84:47 expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
   84 |     repeated_float: [1.5, 16777215, 16777216, 16777217, 1.7014118346046923e+38, 1.7014118346046923e+39]
-     |                                               ^........................................................ expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
+  84 |                                               ^........................................................ expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got integer
 
 internal/testdata/dynamic.const.yaml:84:81 expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got float64
   84 |     repeated_float: [1.5, 16777215, 16777216, 16777217, 1.7014118346046923e+38, 1.7014118346046923e+39]
-     |                                                                                 ^...................... expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got float64
+  84 |                                                                                 ^...................... expected float for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_float, got float64
 
 internal/testdata/dynamic.const.yaml:85:64 expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer
   85 |     repeated_double: [1.5, 9007199254740991, 9007199254740992, 9007199254740993]
-     |                                                                ^................ expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer
+  85 |                                                                ^................ expected double for bufext.cel.expr.conformance.proto3.TestAllTypes.repeated_double, got integer

--- a/internal/testdata/errors.proto3test.txt
+++ b/internal/testdata/errors.proto3test.txt
@@ -1,19 +1,19 @@
 internal/testdata/errors.proto3test.yaml:2:1 unknown field "bad", expended one of [values]
    2 | bad: wat
-     | ^....................................... unknown field "bad", expended one of [values]
+   2 | ^....................................... unknown field "bad", expended one of [values]
 
 internal/testdata/errors.proto3test.yaml:3:4 expected sequence, got scalar
    3 | 1: 2
-     |    ^.................................... expected sequence, got scalar
+   3 |    ^.................................... expected sequence, got scalar
 
 internal/testdata/errors.proto3test.yaml:4:1 unknown field "-1", expended one of [values]
    4 | -1: 3
-     | ^....................................... unknown field "-1", expended one of [values]
+   4 | ^....................................... unknown field "-1", expended one of [values]
 
 internal/testdata/errors.proto3test.yaml:5:1 expected scalar, got sequence
    5 | [1, 2]: 2
-     | ^....................................... expected scalar, got sequence
+   5 | ^....................................... expected scalar, got sequence
 
 internal/testdata/errors.proto3test.yaml:7:5 unknown field "wat", expended one of [single_int32 single_int64 single_uint32 single_uint64 single_sint32 single_sint64 single_fixed32 ...]
    7 |   - wat: 1
-     |     ^................................... unknown field "wat", expended one of [single_int32 single_int64 single_uint32 single_uint64 single_sint32 single_sint64 single_fixed32 ...]
+   7 |     ^................................... unknown field "wat", expended one of [single_int32 single_int64 single_uint32 single_uint64 single_sint32 single_sint64 single_fixed32 ...]

--- a/internal/testdata/validate.validate.txt
+++ b/internal/testdata/validate.validate.txt
@@ -1,35 +1,35 @@
 internal/testdata/validate.validate.yaml:2:18 cases[0].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    2 |   - float_gt_lt: 0
-     |                  ^...................... cases[0].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   2 |                  ^...................... cases[0].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:3:18 cases[1].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    3 |   - float_gt_lt: 10
-     |                  ^...................... cases[1].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   3 |                  ^...................... cases[1].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:4:18 cases[2].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    4 |   - float_gt_lt: 10.5
-     |                  ^...................... cases[2].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   4 |                  ^...................... cases[2].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:5:18 cases[3].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    5 |   - float_gt_lt: -0.5
-     |                  ^...................... cases[3].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   5 |                  ^...................... cases[3].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:6:16 cases[4].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    6 |   - floatGtLt: 10.5
-     |                ^........................ cases[4].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   6 |                ^........................ cases[4].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:7:8 cases[5].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
    7 |   - 2: -Infinity
-     |        ^................................ cases[5].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+   7 |        ^................................ cases[5].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:11:7 cases[6].string_map["c1"]: value does not match regex pattern `^[a-z]+$` (string.pattern)
   11 |       c1: B
-     |       ^................................. cases[6].string_map["c1"]: value does not match regex pattern `^[a-z]+$` (string.pattern)
+  11 |       ^................................. cases[6].string_map["c1"]: value does not match regex pattern `^[a-z]+$` (string.pattern)
 
 internal/testdata/validate.validate.yaml:12:5 cases[7].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
   12 |   - string_map:
-     |     ^................................... cases[7].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
+  12 |     ^................................... cases[7].float_gt_lt: value must be greater than 0 and less than 10 (float.gt_lt)
 
 internal/testdata/validate.validate.yaml:13:10 cases[7].string_map["b"]: value does not match regex pattern `^[A-Z]+$` (string.pattern)
   13 |       b: B1
-     |          ^.............................. cases[7].string_map["b"]: value does not match regex pattern `^[A-Z]+$` (string.pattern)
+  13 |          ^.............................. cases[7].string_map["b"]: value does not match regex pattern `^[A-Z]+$` (string.pattern)

--- a/protoyaml_test.go
+++ b/protoyaml_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestParseFieldPath(t *testing.T) {
@@ -32,19 +33,19 @@ func TestParseFieldPath(t *testing.T) {
 		Path   string
 		Expect []string
 	}{
-		{"", nil},
-		{"foo", []string{"foo"}},
-		{"foo.bar", []string{"foo", "bar"}},
-		{"foo[0]", []string{"foo", "0"}},
-		{"foo[0].bar", []string{"foo", "0", "bar"}},
-		{"foo[0][1]", []string{"foo", "0", "1"}},
-		{"foo.0.1.bar", []string{"foo", "0", "1", "bar"}},
-		{"foo.bar[0]", []string{"foo", "bar", "0"}},
-		{"foo.bar[0].baz", []string{"foo", "bar", "0", "baz"}},
-		{`foo["bar"].baz`, []string{"foo", "bar", "baz"}},
-		{`foo["bar"].baz[0]`, []string{"foo", "bar", "baz", "0"}},
-		{`foo["b\"ar"].baz[0]`, []string{"foo", "b\"ar", "baz", "0"}},
-		{`foo["b.ar"].baz`, []string{"foo", "b.ar", "baz"}},
+		{Path: "", Expect: nil},
+		{Path: "foo", Expect: []string{"foo"}},
+		{Path: "foo.bar", Expect: []string{"foo", "bar"}},
+		{Path: "foo[0]", Expect: []string{"foo", "0"}},
+		{Path: "foo[0].bar", Expect: []string{"foo", "0", "bar"}},
+		{Path: "foo[0][1]", Expect: []string{"foo", "0", "1"}},
+		{Path: "foo.0.1.bar", Expect: []string{"foo", "0", "1", "bar"}},
+		{Path: "foo.bar[0]", Expect: []string{"foo", "bar", "0"}},
+		{Path: "foo.bar[0].baz", Expect: []string{"foo", "bar", "0", "baz"}},
+		{Path: `foo["bar"].baz`, Expect: []string{"foo", "bar", "baz"}},
+		{Path: `foo["bar"].baz[0]`, Expect: []string{"foo", "bar", "baz", "0"}},
+		{Path: `foo["b\"ar"].baz[0]`, Expect: []string{"foo", "b\"ar", "baz", "0"}},
+		{Path: `foo["b.ar"].baz`, Expect: []string{"foo", "b.ar", "baz"}},
 	} {
 		testCase := testCase
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -58,6 +59,27 @@ func TestParseFieldPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDuration(t *testing.T) {
+	val := durationpb.Duration{
+		Seconds: 3600,
+	}
+	data, err := Marshal(&val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "seconds: 3600\n" {
+		t.Fatalf("Expected seconds: 3600, got %s", string(data))
+	}
+	actual := &durationpb.Duration{}
+	if err := Unmarshal(data, actual); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(&val, actual) {
+		t.Fatalf("Expected %v, got %v", &val, actual)
+	}
+
 }
 
 func TestCombinatorial(t *testing.T) {


### PR DESCRIPTION
Some output cases trim multilined error messages. This makes sure the snippit and the arrows stay aligned.