### PR TITLE
Drop actions cache for setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-skeleton-oss-go-ci-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-skeleton-oss-go-ci-
       - name: Test
         run: make test
       - name: Lint


### PR DESCRIPTION
v4 enables caching by default: https://github.com/actions/setup-go#v4