### PR TITLE
Pass through indent size encoding option

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -15,6 +15,7 @@
 package protoyaml
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -32,6 +33,9 @@ func Marshal(message proto.Message) ([]byte, error) {
 //
 // It uses similar options to protojson.MarshalOptions.
 type MarshalOptions struct {
+	// The number of spaces to indent. Passed to yaml.Encoder.SetIndent.
+	// If 0, uses the default indent of yaml.v3 (4)
+	Indent int
 	// AllowPartial allows messages that have missing required fields to marshal
 	// without returning an error.
 	AllowPartial bool
@@ -68,5 +72,11 @@ func (o MarshalOptions) Marshal(message proto.Message) ([]byte, error) {
 		return nil, err
 	}
 	// Write the JSON back out as YAML
-	return yaml.Marshal(jsonVal)
+	buffer := &bytes.Buffer{}
+	encoder := yaml.NewEncoder(buffer)
+	encoder.SetIndent(o.Indent)
+	if err := encoder.Encode(jsonVal); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }

--- a/encode.go
+++ b/encode.go
@@ -34,7 +34,7 @@ func Marshal(message proto.Message) ([]byte, error) {
 // It uses similar options to protojson.MarshalOptions.
 type MarshalOptions struct {
 	// The number of spaces to indent. Passed to yaml.Encoder.SetIndent.
-	// If 0, uses the default indent of yaml.v3 (4)
+	// If 0, uses the default indent of yaml.v3.
 	Indent int
 	// AllowPartial allows messages that have missing required fields to marshal
 	// without returning an error.

--- a/encode_test.go
+++ b/encode_test.go
@@ -136,3 +136,18 @@ func TestEnumEncoding(t *testing.T) {
 		t.Fatalf("Expected %v, got %v", ival.GetRepeatedNestedEnum()[4], oval.GetRepeatedNestedEnum()[4])
 	}
 }
+
+func TestIndentSize(t *testing.T) {
+	t.Parallel()
+	ival := &proto3.TestAllTypes{
+		RepeatedNestedEnum: []proto3.TestAllTypes_NestedEnum{proto3.TestAllTypes_BAR, -1, 0, 1, 100},
+	}
+	// Encode the message as YAML
+	data, err := MarshalOptions{Indent: 2}.Marshal(ival)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "repeatedNestedEnum:\n  - BAR\n  - -1\n  - FOO\n  - BAR\n  - 100\n" {
+		t.Fatalf("Expected 2 space indent, got %q", string(data))
+	}
+}


### PR DESCRIPTION
To the yaml.v3 library. See https://github.com/bufbuild/protoyaml-go/issues/17 for context