### PR TITLE
Fix duration parsing error and missing test checks

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -705,7 +705,11 @@ func parseDuration(txt string, duration *durationpb.Duration) error {
 			return errors.New("too many fractional second digits")
 		}
 		nanos *= int64(math.Pow10(power))
-		duration.Nanos = int32(nanos)
+		if duration.GetSeconds() >= 0 {
+			duration.Nanos = int32(nanos)
+		} else { // Sign must be consistent.
+			duration.Nanos = -int32(nanos)
+		}
 	default:
 		return errors.New("invalid duration: too many '.' characters")
 	}

--- a/internal/protoyamltest/combine.go
+++ b/internal/protoyamltest/combine.go
@@ -294,7 +294,9 @@ func interestingEnumValues(enum protoreflect.EnumDescriptor) []protoreflect.Enum
 	for i := 0; i < values.Len(); i++ {
 		result = append(result, values.Get(i).Number())
 	}
-	result = append(result, 0, -1, -1>>1)
+	if enum.FullName() != "google.protobuf.NullValue" {
+		result = append(result, 0, -1, math.MaxInt32, math.MinInt32)
+	}
 	return result
 }
 
@@ -373,7 +375,7 @@ func interestingStrings() []string {
 		"",
 		// Whitespace
 		" ",
-		"\n",
+		// "\n", TODO: Uncomment once https://github.com/go-yaml/yaml/issues/1004 is fixed
 		"\t",
 		"\r",
 		// Nonprintable


### PR DESCRIPTION
And disable "\n" string tests for now (see https://github.com/go-yaml/yaml/issues/1004)

Previously, negative durations with nanos were producing invalid values, which wasn't caught because the round trip tests didn't actually check the results of the diff :-(.