### PR TITLE
Fix parsing of negative nanos duration

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -673,10 +673,12 @@ const (
 // Format is decimal seconds with up to 9 fractional digits, followed by an 's'.
 func parseDuration(txt string, duration *durationpb.Duration) error {
 	// Remove trailing s.
-	if txt[len(txt)-1] != 's' {
+	txt = strings.TrimSpace(txt)
+	if len(txt) == 0 || txt[len(txt)-1] != 's' {
 		return errors.New("missing trailing 's'")
 	}
 	value := txt[:len(txt)-1]
+	isNeg := strings.HasPrefix(value, "-")
 
 	// Split into seconds and nanos.
 	parts := strings.Split(value, ".")
@@ -705,10 +707,10 @@ func parseDuration(txt string, duration *durationpb.Duration) error {
 			return errors.New("too many fractional second digits")
 		}
 		nanos *= int64(math.Pow10(power))
-		if duration.GetSeconds() >= 0 {
-			duration.Nanos = int32(nanos)
-		} else { // Sign must be consistent.
+		if isNeg {
 			duration.Nanos = -int32(nanos)
+		} else {
+			duration.Nanos = int32(nanos)
 		}
 	default:
 		return errors.New("invalid duration: too many '.' characters")

--- a/decode_test.go
+++ b/decode_test.go
@@ -51,7 +51,11 @@ func TestParseDuration(t *testing.T) {
 		Input    string
 		Expected *durationpb.Duration
 	}{
+		{Input: "", Expected: nil},
+		{Input: "-", Expected: nil},
+		{Input: "-s", Expected: nil},
 		{Input: "0s", Expected: &durationpb.Duration{}},
+		{Input: "-0s", Expected: &durationpb.Duration{}},
 		{Input: "1s", Expected: &durationpb.Duration{Seconds: 1}},
 		{Input: "-1s", Expected: &durationpb.Duration{Seconds: -1}},
 		{Input: "--1s", Expected: nil},

--- a/internal/protoyamltest/fuzz.go
+++ b/internal/protoyamltest/fuzz.go
@@ -42,10 +42,14 @@ func populateMessage(rnd *rand.Rand, msg proto.Message, depth int) {
 		// Valid values are between -315,576,000,000 and +315,576,000,000 inclusive.
 		if rnd.Intn(2) == 0 {
 			msg.Seconds = rnd.Int63n(631152000000) - 315576000000
+		} else {
+			msg.Seconds = 0
 		}
 		if rnd.Intn(2) == 0 {
 			// Valid values are between 0 and +999,999,999 inclusive.
 			msg.Nanos = rnd.Int31n(1000000000)
+		} else {
+			msg.Nanos = 0
 		}
 		switch {
 		case msg.GetSeconds() < 0:

--- a/internal/protoyamltest/fuzz.go
+++ b/internal/protoyamltest/fuzz.go
@@ -40,11 +40,20 @@ func populateMessage(rnd *rand.Rand, msg proto.Message, depth int) {
 		return
 	case *durationpb.Duration:
 		// Valid values are between -315,576,000,000 and +315,576,000,000 inclusive.
-		msg.Seconds = rnd.Int63n(631152000000) - 315576000000
-		// Valid values are between 0 and +999,999,999 inclusive.
-		msg.Nanos = rnd.Int31n(1000000000)
-		if msg.GetSeconds() < 0 {
+		if rnd.Intn(2) == 0 {
+			msg.Seconds = rnd.Int63n(631152000000) - 315576000000
+		}
+		if rnd.Intn(2) == 0 {
+			// Valid values are between 0 and +999,999,999 inclusive.
+			msg.Nanos = rnd.Int31n(1000000000)
+		}
+		switch {
+		case msg.GetSeconds() < 0:
 			msg.Nanos = -msg.GetNanos()
+		case msg.GetSeconds() == 0:
+			if rnd.Intn(2) == 0 {
+				msg.Nanos = -msg.GetNanos()
+			}
 		}
 		return
 	case *timestamppb.Timestamp:

--- a/protoyaml_test.go
+++ b/protoyaml_test.go
@@ -88,6 +88,10 @@ func TestDuration_DynamicWithNanos(t *testing.T) {
 	for _, testCase := range []*durationpb.Duration{
 		{Seconds: 3600, Nanos: 1001},
 		{Seconds: -3600, Nanos: -1001},
+		{Seconds: 3600},
+		{Seconds: -3600},
+		{Nanos: 1001},
+		{Nanos: -1001},
 	} {
 		data, err := Marshal(testCase)
 		if err != nil {


### PR DESCRIPTION
And update fuzz/combinatorial tests to hit this case. It is unfortunate that the built in duration parsing doesn't have enough precision to use directly.
