### PR TITLE
Match protojson behavior for well known types in Any

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -34,6 +34,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const atTypeFieldName = "@type"
+
 // Validator is an interface for validating a Protobuf message produced from a given YAML node.
 type Validator interface {
 	// Validate the given message.
@@ -153,7 +155,7 @@ func (u *unmarshaler) findAnyTypeURL(node *yaml.Node) string {
 	for i := 1; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i-1]
 		valueNode := node.Content[i]
-		if keyNode.Value == "@type" && u.checkKind(valueNode, yaml.ScalarNode) {
+		if keyNode.Value == atTypeFieldName && u.checkKind(valueNode, yaml.ScalarNode) {
 			typeURL = valueNode.Value
 			break
 		}
@@ -526,10 +528,10 @@ func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message, f
 				switch keyNode.Value {
 				case "value":
 					customNode = node.Content[i]
-				case "@type":
+				case atTypeFieldName:
 					continue // Skip the @type field for Any messages
 				default:
-					u.addErrorf(keyNode, "unknown field %#v, expended one of %v", keyNode.Value, []string{"value", "@type"})
+					u.addErrorf(keyNode, "unknown field %#v, expended one of %v", keyNode.Value, []string{"value", atTypeFieldName})
 					return
 				}
 			}
@@ -551,7 +553,7 @@ func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message, f
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if u.checkKind(keyNode, yaml.ScalarNode) {
-			if forAny && keyNode.Value == "@type" {
+			if forAny && keyNode.Value == atTypeFieldName {
 				continue // Skip the @type field for Any messages
 			}
 			// Get the field Name, JSONName, or Number

--- a/decode.go
+++ b/decode.go
@@ -90,7 +90,7 @@ func (o UnmarshalOptions) unmarshalNode(node *yaml.Node, message proto.Message, 
 		node = node.Content[0]
 	}
 
-	unm.unmarshalMessage(node, message)
+	unm.unmarshalMessage(node, message, false)
 	if unm.validator != nil {
 		err := unm.validator.Validate(message)
 		var verr *protovalidate.ValidationError
@@ -462,7 +462,7 @@ func (u *unmarshaler) unmarshalField(node *yaml.Node, field protoreflect.FieldDe
 	case field.IsMap():
 		u.unmarshalMap(node, field, message.ProtoReflect().Mutable(field).Map())
 	case field.Kind() == protoreflect.MessageKind:
-		u.unmarshalMessage(node, message.ProtoReflect().Mutable(field).Message().Interface())
+		u.unmarshalMessage(node, message.ProtoReflect().Mutable(field).Message().Interface(), false)
 	default:
 		message.ProtoReflect().Set(field, u.unmarshalScalar(node, field, false))
 	}
@@ -475,7 +475,7 @@ func (u *unmarshaler) unmarshalList(node *yaml.Node, field protoreflect.FieldDes
 		case protoreflect.MessageKind, protoreflect.GroupKind:
 			for _, itemNode := range node.Content {
 				msgVal := list.NewElement()
-				u.unmarshalMessage(itemNode, msgVal.Message().Interface())
+				u.unmarshalMessage(itemNode, msgVal.Message().Interface(), false)
 				list.Append(msgVal)
 			}
 		default:
@@ -498,7 +498,7 @@ func (u *unmarshaler) unmarshalMap(node *yaml.Node, field protoreflect.FieldDesc
 			switch mapValueField.Kind() {
 			case protoreflect.MessageKind, protoreflect.GroupKind:
 				mapValue := mapVal.NewValue()
-				u.unmarshalMessage(valueNode, mapValue.Message().Interface())
+				u.unmarshalMessage(valueNode, mapValue.Message().Interface(), false)
 				mapVal.Set(mapKey.MapKey(), mapValue)
 			default:
 				mapVal.Set(mapKey.MapKey(), u.unmarshalScalar(valueNode, mapValueField, false))
@@ -512,11 +512,31 @@ func isNull(node *yaml.Node) bool {
 }
 
 // Unmarshal the given yaml node into the given proto.Message.
-func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message) {
+func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message, forAny bool) {
 	// Check for a custom unmarshaler
-	custom, ok := u.custom[message.ProtoReflect().Descriptor().FullName()]
-	if ok && custom(u, node, message) {
-		return // Custom unmarshaler handled the decoding
+
+	if custom, ok := u.custom[message.ProtoReflect().Descriptor().FullName()]; ok {
+		customNode := node
+		if forAny { // For Any messages, the custom unmarshaler is expecting the 'value' field.
+			if !u.checkKind(node, yaml.MappingNode) {
+				return
+			}
+			for i := 1; i < len(node.Content); i += 2 {
+				keyNode := node.Content[i-1]
+				switch keyNode.Value {
+				case "value":
+					customNode = node.Content[i]
+				case "@type":
+					continue // Skip the @type field for Any messages
+				default:
+					u.addErrorf(keyNode, "unknown field %#v, expended one of %v", keyNode.Value, []string{"value", "@type"})
+					return
+				}
+			}
+		}
+		if custom(u, customNode, message) {
+			return // Custom unmarshaler handled the decoding
+		}
 	}
 	if isNull(node) {
 		return // Null is always allowed for messages
@@ -530,7 +550,10 @@ func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message) {
 	fields := message.ProtoReflect().Descriptor().Fields()
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
-		if u.checkKind(keyNode, yaml.ScalarNode) && keyNode.Value != "@type" {
+		if u.checkKind(keyNode, yaml.ScalarNode) {
+			if forAny && keyNode.Value == "@type" {
+				continue // Skip the @type field for Any messages
+			}
 			// Get the field Name, JSONName, or Number
 			if field := findField(keyNode.Value, fields); field != nil {
 				valueNode := node.Content[i+1]
@@ -583,7 +606,7 @@ func unmarshalAnyMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) b
 	}
 
 	protoVal := msgType.New()
-	unm.unmarshalMessage(node, protoVal.Interface())
+	unm.unmarshalMessage(node, protoVal.Interface(), true)
 	if err = anyVal.MarshalFrom(protoVal.Interface()); err != nil {
 		unm.addErrorf(node, "failed to marshal %v: %v", msgType.Descriptor().FullName(), err)
 	}
@@ -723,9 +746,6 @@ func unmarshalTimestampMsg(unm *unmarshaler, node *yaml.Node, message proto.Mess
 
 // Forwards unmarshaling to the "value" field of the given wrapper message.
 func unmarshalWrapperMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
-	if isNull(node) {
-		return true
-	}
 	valueField := message.ProtoReflect().Descriptor().Fields().ByName("value")
 	if node.Kind == yaml.MappingNode || valueField == nil {
 		return false

--- a/decode.go
+++ b/decode.go
@@ -513,6 +513,8 @@ func isNull(node *yaml.Node) bool {
 	return node.Tag == "!!null"
 }
 
+// Resolve the node to be used with the custom unmarshaler. Returns nil if the
+// there was an error.
 func (u *unmarshaler) findNodeForCustom(node *yaml.Node, forAny bool) *yaml.Node {
 	if !forAny {
 		return node

--- a/internal/testdata/basic.proto3test.txt
+++ b/internal/testdata/basic.proto3test.txt
@@ -229,3 +229,7 @@ internal/testdata/basic.proto3test.yaml:126:23 invalid timestamp: parsing time "
 internal/testdata/basic.proto3test.yaml:130:23 expected fields for google.protobuf.Timestamp, got sequence
  130 |   - single_timestamp: []
  130 |                       ^................. expected fields for google.protobuf.Timestamp, got sequence
+
+internal/testdata/basic.proto3test.yaml:135:7 unknown field "@type", expended one of [value]
+ 135 |       "@type": type.googleapis.com/google.protobuf.Int32Value
+ 135 |       ^...................................................... unknown field "@type", expended one of [value]

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -131,3 +131,6 @@ values:
   - single_int32_wrapper: 1
   - single_int32_wrapper:
       value: 1
+  - single_int32_wrapper:
+      "@type": type.googleapis.com/google.protobuf.Int32Value
+      value: 1

--- a/internal/testdata/dynamic.const.txt
+++ b/internal/testdata/dynamic.const.txt
@@ -157,3 +157,7 @@ internal/testdata/dynamic.const.yaml:84:81 invalid float: strconv.ParseFloat: pa
 internal/testdata/dynamic.const.yaml:88:5 unknown field "seconds", expended one of [value @type]
   88 |     seconds: 1
   88 |     ^................................... unknown field "seconds", expended one of [value @type]
+
+internal/testdata/dynamic.const.yaml:111:5 missing "value" field
+ 111 |     "@type": type.googleapis.com/google.protobuf.BoolValue
+ 111 |     ^..................................................... missing "value" field

--- a/internal/testdata/dynamic.const.txt
+++ b/internal/testdata/dynamic.const.txt
@@ -153,3 +153,7 @@ internal/testdata/dynamic.const.yaml:83:57 invalid integer: precision loss
 internal/testdata/dynamic.const.yaml:84:81 invalid float: strconv.ParseFloat: parsing "1.7014118346046923e+39": value out of range
   84 |     repeated_float: [1.5, 16777215, 16777216, 16777217, 1.7014118346046923e+38, 1.7014118346046923e+39]
   84 |                                                                                 ^...................... invalid float: strconv.ParseFloat: parsing "1.7014118346046923e+39": value out of range
+
+internal/testdata/dynamic.const.yaml:88:5 unknown field "seconds", expended one of [value @type]
+  88 |     seconds: 1
+  88 |     ^................................... unknown field "seconds", expended one of [value @type]

--- a/internal/testdata/dynamic.const.yaml
+++ b/internal/testdata/dynamic.const.yaml
@@ -97,3 +97,13 @@ values:
       value:
         "@type": type.googleapis.com/google.protobuf.BoolValue
         value: true
+  dynamic_struct:
+    "@type": type.googleapis.com/google.protobuf.Struct
+    value:
+      my_field: true
+      other_field: 1
+  dynamic_list:
+    "@type": type.googleapis.com/google.protobuf.ListValue
+    value:
+      - true
+      - 1

--- a/internal/testdata/dynamic.const.yaml
+++ b/internal/testdata/dynamic.const.yaml
@@ -107,3 +107,5 @@ values:
     value:
       - true
       - 1
+  dynamic_no_value:
+    "@type": type.googleapis.com/google.protobuf.BoolValue

--- a/internal/testdata/dynamic.const.yaml
+++ b/internal/testdata/dynamic.const.yaml
@@ -83,3 +83,17 @@ values:
     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
     repeated_float: [1.5, 16777215, 16777216, 16777217, 1.7014118346046923e+38, 1.7014118346046923e+39]
     repeated_double: [1.5, 9007199254740991, 9007199254740992, 9007199254740993]
+  dynamic_duration_bad:
+    "@type": type.googleapis.com/google.protobuf.Duration
+    seconds: 1
+    nanos: 1
+  dynamic_duration:
+    "@type": type.googleapis.com/google.protobuf.Duration
+    value: 1.000000001s
+  dynamic_any_any:
+    "@type": type.googleapis.com/google.protobuf.Any
+    value:
+      "@type": type.googleapis.com/google.protobuf.Any
+      value:
+        "@type": type.googleapis.com/google.protobuf.BoolValue
+        value: true

--- a/protoyaml_test.go
+++ b/protoyaml_test.go
@@ -302,12 +302,12 @@ func TestAnyValue(t *testing.T) {
 		t.Run(testCase.Input, func(t *testing.T) {
 			t.Parallel()
 			data := []byte(`{"@type": "type.googleapis.com/google.protobuf.Value", value: ` + testCase.Input + `}`)
-			any := &anypb.Any{}
-			if err := Unmarshal(data, any); err != nil {
+			anyVal := &anypb.Any{}
+			if err := Unmarshal(data, anyVal); err != nil {
 				t.Fatal(err)
 			}
 			actual := &structpb.Value{}
-			if err := any.UnmarshalTo(actual); err != nil {
+			if err := anyVal.UnmarshalTo(actual); err != nil {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(testCase.Expected, actual, protocmp.Transform()); diff != "" {


### PR DESCRIPTION
Where there value is always specified via a 'value' field.
Also only ignore "@type" when decoding an any.
This also fixes https://github.com/bufbuild/protoyaml-go/issues/20