### PR TITLE
Update to require go 1.21; add testing and linting with 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   gocyclo:
     min-complexity: 15
@@ -37,39 +35,31 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated as of golangci v1.58.0
+    - exhaustive
+    - exhaustruct
+    - exportloopref     # deprecated as of golangci v1.60.2
     - funlen            # rely on code review to limit function length
+    - gochecknoglobals
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
+    - mnd
     - nlreturn          # generous whitespace violates house style
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
+    - nonamedreturns
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
-    - exhaustive
-    - exhaustruct
-    - nonamedreturns
-    - mnd
-    - err113
-    - gochecknoglobals
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
     # Loosen requirements on tests
   exclude-rules:
     - path: _test.go

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ $(BIN):
 	@mkdir -p $(BIN)
 
 $(BIN)/buf: $(BIN) Makefile
-	go install github.com/bufbuild/buf/cmd/buf@v1.36.0
+	go install github.com/bufbuild/buf/cmd/buf@v1.39.0
 
 $(BIN)/license-header: $(BIN) Makefile
 	go install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.36.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.39.0
 
 $(BIN)/golangci-lint: $(BIN) Makefile
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3

--- a/decode.go
+++ b/decode.go
@@ -129,7 +129,7 @@ func ParseDuration(str string) (*durationpb.Duration, error) {
 		return nil, errors.New("invalid duration: out of range")
 	}
 	result.Seconds = quo.Int64()
-	result.Nanos = int32(rem.Int64())
+	result.Nanos = int32(rem.Int64()) //nolint:gosec // not an overflow risk; value is less than 2^30
 	return result, nil
 }
 
@@ -260,10 +260,12 @@ func (u *unmarshaler) unmarshalScalar(
 	case protoreflect.BoolKind:
 		return protoreflect.ValueOfBool(u.unmarshalBool(node, forKey)), true
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		//nolint:gosec // not overflow risk since unmarshalInteger does range check
 		return protoreflect.ValueOfInt32(int32(u.unmarshalInteger(node, 32))), true
 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
 		return protoreflect.ValueOfInt64(u.unmarshalInteger(node, 64)), true
 	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		//nolint:gosec // not overflow risk since unmarshalUnsigned does range check
 		return protoreflect.ValueOfUint32(uint32(u.unmarshalUnsigned(node, 32))), true
 	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
 		return protoreflect.ValueOfUint64(u.unmarshalUnsigned(node, 64)), true
@@ -344,10 +346,13 @@ func (u *unmarshaler) unmarshalEnum(node *yaml.Node, field protoreflect.FieldDes
 		if err != nil {
 			u.addErrorf(node, "unknown enum value %#v, expected one of %v", node.Value,
 				getEnumValueNames(enumDesc.Values()))
+			return 0
 		} else if err := lit.checkI32(field); err != nil {
 			u.addErrorf(node, "%w, expected one of %v", err,
 				getEnumValueNames(enumDesc.Values()))
+			return 0
 		}
+		//nolint:gosec // not overflow risk since list.checkI32 call above does range check
 		num := protoreflect.EnumNumber(lit.value)
 		if lit.negative {
 			num = -num
@@ -398,12 +403,14 @@ func (u *unmarshaler) unmarshalInteger(node *yaml.Node, bits int) int64 {
 	}
 	if lit.negative {
 		if lit.value <= 1<<(bits-1) {
+			//nolint:gosec // we just checked on previous line so not overflow risk
 			return -int64(lit.value)
 		}
 		u.addErrorf(node, "integer is too small: < %v", -(1 << (bits - 1)))
 	} else if lit.value >= 1<<(bits-1) {
 		u.addErrorf(node, "integer is too large: > %v", 1<<(bits-1)-1)
 	}
+	//nolint:gosec // we just checked above so not overflow risk
 	return int64(lit.value)
 }
 
@@ -412,7 +419,7 @@ func getFieldNames(fields protoreflect.FieldDescriptors) []protoreflect.Name {
 	for i := 0; i < fields.Len(); i++ {
 		names = append(names, fields.Get(i).Name())
 		if i > 5 {
-			names = append(names, protoreflect.Name("..."))
+			names = append(names, "...")
 			break
 		}
 	}
@@ -424,7 +431,7 @@ func getEnumValueNames(values protoreflect.EnumValueDescriptors) []protoreflect.
 	for i := 0; i < values.Len(); i++ {
 		names = append(names, values.Get(i).Name())
 		if i > 5 {
-			names = append(names, protoreflect.Name("..."))
+			names = append(names, "...")
 			break
 		}
 	}
@@ -539,7 +546,8 @@ func (u *unmarshaler) findField(key string, msgDesc protoreflect.MessageDescript
 		return field, nil
 	}
 	num, err := strconv.ParseInt(key, 10, 32)
-	if err == nil {
+	if err == nil && num > 0 && num <= math.MaxInt32 {
+		//nolint:gosec // we just checked on previous line so not overflow risk
 		if field := fields.ByNumber(protoreflect.FieldNumber(num)); field != nil {
 			return field, nil
 		}
@@ -797,7 +805,7 @@ func parseTimestamp(txt string, timestamp *timestamppb.Timestamp) error {
 	}
 
 	timestamp.Seconds = secs
-	timestamp.Nanos = int32(parsed.Nanosecond())
+	timestamp.Nanos = int32(parsed.Nanosecond()) //nolint:gosec // not an overflow risk; value is less than 2^30
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protoyaml-go
 
-go 1.20
+go 1.21
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.33.0-20240401165935-b983156c5e99.1


### PR DESCRIPTION
In order for the linters to work with 1.23, had to update golangci-lint, too, which also required some updates to the config and to code. Most of the code changes are for a "gosec" check related to narrowing integer conversions. All of the code was already doing adequate range checks (well almost; I had to add one), so most of the changes are "nolint" comments on these places.