### PR TITLE
Add support for cel expressions to scalar types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters-settings:
           - github.com/bufbuild/protoyaml-go/decode
           - github.com/bufbuild/protovalidate-go
           - buf.build/gen/go/bufbuild/protovalidate
+          - github.com/google/cel-go
   errcheck:
     check-type-assertions: true
   forbidigo:

--- a/decode.go
+++ b/decode.go
@@ -760,8 +760,8 @@ func (u *unmarshaler) unmarshalList(node *yaml.Node, field protoreflect.FieldDes
 		case protoreflect.MessageKind, protoreflect.GroupKind:
 			for _, itemNode := range node.Content {
 				msgVal := list.NewElement()
-				u.unmarshalMessage(itemNode, msgVal.Message().Interface(), false)
 				list.Append(msgVal)
+				u.unmarshalMessage(itemNode, msgVal.Message().Interface(), false)
 			}
 		default:
 			for _, itemNode := range node.Content {
@@ -1103,10 +1103,10 @@ func dynSetListValue(message proto.Message, list *structpb.ListValue) bool {
 	values := message.ProtoReflect().Mutable(valuesFld).List()
 	for _, item := range list.GetValues() {
 		value := values.NewElement()
+		values.Append(value)
 		if !dynSetValue(value.Message().Interface(), item) {
 			return false
 		}
-		values.Append(value)
 	}
 	return true
 }

--- a/internal/testdata/basic.proto3test.txt
+++ b/internal/testdata/basic.proto3test.txt
@@ -1,8 +1,8 @@
-internal/testdata/basic.proto3test.yaml:7:18 expected bool, got "1"
+internal/testdata/basic.proto3test.yaml:7:18 expected bool, got int
    7 |   - single_bool: 1
    7 | .................^
 
-internal/testdata/basic.proto3test.yaml:8:18 expected bool, got "0"
+internal/testdata/basic.proto3test.yaml:8:18 expected bool, got int
    8 |   - single_bool: 0
    8 | .................^
 
@@ -98,14 +98,6 @@ internal/testdata/basic.proto3test.yaml:51:19 invalid integer: precision loss
   51 |   - single_int64: 9007199254740992.0
   51 | ..................^
 
-internal/testdata/basic.proto3test.yaml:52:19 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
-  52 |   - single_int32: --1
-  52 | ..................^
-
-internal/testdata/basic.proto3test.yaml:53:19 invalid integer: strconv.ParseUint: parsing "--1": invalid syntax
-  53 |   - single_int32: ---1
-  53 | ..................^
-
 internal/testdata/basic.proto3test.yaml:54:19 invalid integer: strconv.ParseUint: parsing "inf": invalid syntax
   54 |   - single_int32: inf
   54 | ..................^
@@ -122,15 +114,15 @@ internal/testdata/basic.proto3test.yaml:57:19 invalid integer: strconv.ParseUint
   57 |   - single_int32: .nan
   57 | ..................^
 
-internal/testdata/basic.proto3test.yaml:58:20 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
+internal/testdata/basic.proto3test.yaml:58:20 expected unsigned integer, got int
   58 |   - single_uint32: -1
   58 | ...................^
 
-internal/testdata/basic.proto3test.yaml:63:20 integer is too large: > 4294967295
+internal/testdata/basic.proto3test.yaml:63:20 unsigned integer is too large: > 4294967295
   63 |   - single_uint32: 4294967296
   63 | ...................^
 
-internal/testdata/basic.proto3test.yaml:65:20 invalid integer: precision loss
+internal/testdata/basic.proto3test.yaml:65:20 invalid unsigned integer: precision loss
   65 |   - single_uint64: 18446744073709551616
   65 | ...................^
 
@@ -233,3 +225,7 @@ internal/testdata/basic.proto3test.yaml:130:23 expected fields for google.protob
 internal/testdata/basic.proto3test.yaml:135:7 unknown field "@type", expected one of [value]
  135 |       "@type": type.googleapis.com/google.protobuf.Int32Value
  135 | ......^
+
+internal/testdata/basic.proto3test.yaml:142:28 expected unsigned integer, got int
+ 142 |   - single_uint32_wrapper: 1 - 2
+ 142 | ...........................^

--- a/internal/testdata/basic.proto3test.txt
+++ b/internal/testdata/basic.proto3test.txt
@@ -210,7 +210,7 @@ internal/testdata/basic.proto3test.yaml:121:23 invalid timestamp: parsing time "
  121 |   - single_timestamp: 9999-12-31T23:59:60Z
  121 | ......................^
 
-internal/testdata/basic.proto3test.yaml:125:23 invalid timestamp: parsing time "10" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "10" as "2006"
+internal/testdata/basic.proto3test.yaml:125:23 expected timestamp, got int
  125 |   - single_timestamp: 10
  125 | ......................^
 

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -144,6 +144,6 @@ values:
   - single_timestamp: now
   - single_duration: now - timestamp("1970-01-01T00:00:00Z")
   - map_int64_nested_type:
-      1: { payload: { single_int32: 1 } }
-      2: { payload: { single_sint32: "this.values[135].map_int64_nested_type[1].payload.single_int32 + 1" } }
+      1: { payload: { single_int32: 1, single_fixed32: "this.values[135].map_int64_nested_type[1].payload.single_int32 + 1" } }
+      2: { payload: { single_sint32: "this.values[135].map_int64_nested_type[1].payload.single_fixed32 + 1u" } }
       3: "this.values[135].map_int64_nested_type[2]"

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -143,3 +143,7 @@ values:
   - single_bool: "!this.values[0].single_bool"
   - single_timestamp: now
   - single_duration: now - timestamp("1970-01-01T00:00:00Z")
+  - map_int64_nested_type:
+      1: { payload: { single_int32: 1 } }
+      2: { payload: { single_sint32: "this.values[135].map_int64_nested_type[1].payload.single_int32 + 1" } }
+      3: "this.values[135].map_int64_nested_type[2]"

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -140,4 +140,4 @@ values:
   - single_string: !cel '"hi" + "there"'
   - single_int32_wrapper: 1 + 3
   - single_uint32_wrapper: 1 - 2
-  - single_bool: this.values[0].single_bool
+  - single_bool: "!this.values[0].single_bool"

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -136,3 +136,7 @@ values:
       value: 1
   - single_bytes: "nopad+"
   - single_bytes: "web-safe__"
+  - single_bytes: b"hi"
+  - single_string: !!cel '"hi" + "there"'
+  - single_int32_wrapper: 1 + 3
+  - single_uint32_wrapper: 1 - 2

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -137,6 +137,6 @@ values:
   - single_bytes: "nopad+"
   - single_bytes: "web-safe__"
   - single_bytes: b"hi"
-  - single_string: !!cel '"hi" + "there"'
+  - single_string: !cel '"hi" + "there"'
   - single_int32_wrapper: 1 + 3
   - single_uint32_wrapper: 1 - 2

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -140,3 +140,4 @@ values:
   - single_string: !cel '"hi" + "there"'
   - single_int32_wrapper: 1 + 3
   - single_uint32_wrapper: 1 - 2
+  - single_bool: this.values[0].single_bool

--- a/internal/testdata/basic.proto3test.yaml
+++ b/internal/testdata/basic.proto3test.yaml
@@ -141,3 +141,5 @@ values:
   - single_int32_wrapper: 1 + 3
   - single_uint32_wrapper: 1 - 2
   - single_bool: "!this.values[0].single_bool"
+  - single_timestamp: now
+  - single_duration: now - timestamp("1970-01-01T00:00:00Z")

--- a/internal/testdata/dynamic.const.txt
+++ b/internal/testdata/dynamic.const.txt
@@ -6,7 +6,7 @@ internal/testdata/dynamic.const.yaml:13:12 expected scalar, got mapping
   13 |     value: {}
   13 | ...........^
 
-internal/testdata/dynamic.const.yaml:16:12 expected bool, got "null"
+internal/testdata/dynamic.const.yaml:16:12 expected bool, got null_type
   16 |     value: null
   16 | ...........^
 
@@ -82,11 +82,11 @@ internal/testdata/dynamic.const.yaml:70:7 expected scalar, got sequence
   70 |       []: true
   70 | ......^
 
-internal/testdata/dynamic.const.yaml:71:7 expected bool, got "1"
+internal/testdata/dynamic.const.yaml:71:7 expected bool, got int
   71 |       1: true
   71 | ......^
 
-internal/testdata/dynamic.const.yaml:72:13 expected bool, got "1"
+internal/testdata/dynamic.const.yaml:72:13 expected bool, got int
   72 |       true: 1
   72 | ............^
 
@@ -118,27 +118,27 @@ internal/testdata/dynamic.const.yaml:81:92 integer is too large: > 9223372036854
   81 |     repeated_int64: [1.5, -9223372036854775808, -9223372036854775809, 9223372036854775807, 9223372036854775808]
   81 | ...........................................................................................^
 
-internal/testdata/dynamic.const.yaml:82:23 invalid integer: precision loss
+internal/testdata/dynamic.const.yaml:82:23 expected unsigned integer, got double
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
   82 | ......................^
 
-internal/testdata/dynamic.const.yaml:82:28 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
+internal/testdata/dynamic.const.yaml:82:28 expected unsigned integer, got int
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
   82 | ...........................^
 
-internal/testdata/dynamic.const.yaml:82:47 integer is too large: > 4294967295
+internal/testdata/dynamic.const.yaml:82:47 unsigned integer is too large: > 4294967295
   82 |     repeated_uint32: [1.5, -1, 0, 4294967295, 4294967296]
   82 | ..............................................^
 
-internal/testdata/dynamic.const.yaml:83:23 invalid integer: precision loss
+internal/testdata/dynamic.const.yaml:83:23 expected unsigned integer, got double
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
   83 | ......................^
 
-internal/testdata/dynamic.const.yaml:83:28 invalid integer: strconv.ParseUint: parsing "-1": invalid syntax
+internal/testdata/dynamic.const.yaml:83:28 expected unsigned integer, got int
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
   83 | ...........................^
 
-internal/testdata/dynamic.const.yaml:83:57 invalid integer: precision loss
+internal/testdata/dynamic.const.yaml:83:57 invalid unsigned integer: precision loss
   83 |     repeated_uint64: [1.5, -1, 0, 18446744073709551615, 18446744073709551616]
   83 | ........................................................^
 

--- a/internal/testdata/dynamic.const.txt
+++ b/internal/testdata/dynamic.const.txt
@@ -54,19 +54,19 @@ internal/testdata/dynamic.const.yaml:52:36 invalid float: strconv.ParseFloat: pa
   52 |     repeated_double: [1, "1", 1.5, hi, Infinity, NaN, 9007199254740991, 9007199254740992, 9007199254740993]
   52 | ...................................^
 
-internal/testdata/dynamic.const.yaml:55:22 invalid base64: illegal base64 data at input byte 0
+internal/testdata/dynamic.const.yaml:55:22 expected bytes, got int
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
   55 | .....................^
 
-internal/testdata/dynamic.const.yaml:55:25 invalid base64: illegal base64 data at input byte 0
+internal/testdata/dynamic.const.yaml:55:25 expected bytes, got int
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
   55 | ........................^
 
-internal/testdata/dynamic.const.yaml:55:30 invalid base64: illegal base64 data at input byte 1
+internal/testdata/dynamic.const.yaml:55:30 expected bytes, got double
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
   55 | .............................^
 
-internal/testdata/dynamic.const.yaml:55:68 invalid base64: illegal base64 data at input byte 4
+internal/testdata/dynamic.const.yaml:55:68 expected bytes, got bool
   55 |     repeated_bytes: [1, "1", 1.5, hi, Infinity, NaN, "Zg==", true, false, null]
   55 | ...................................................................^
 


### PR DESCRIPTION
Since protoyaml depends on protovalidate, cel-go is already a dependency.
Scalars that do not trivially parse are passed through cel to see if they can be evaluated.
The tag `!cel` can be used to force cel evaluation for strings.
Similar to protovalidate, `this` and `now` are bound.