### PR TITLE
Add support for custom unmarshalers

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -41,7 +41,7 @@ var (
 	// compiler complaining about a potential initialization cycle
 	// (the initializer expression refers to the function
 	// unmarshalAnyMsg, which indirectly refers back to this var).
-	wktUnmarshallers map[protoreflect.FullName]customUnmarshaller
+	wktUnmarshalers map[protoreflect.FullName]customUnmarshaler
 )
 
 // UnmarshalOptions is a configurable YAML format parser for Protobuf messages.
@@ -52,8 +52,8 @@ type UnmarshalOptions struct {
 	Path string
 	// Validator is a validator to run after unmarshaling a message.
 	Validator Validator
-	// CustomUnmarshaller is a custom unmarshaller to use for specific message types.
-	CustomUnmarshaller CustomUnmarshaller
+	// CustomUnmarshaler is a custom unmarshaler to use for specific message types.
+	CustomUnmarshaler CustomUnmarshaler
 	// Resolver is the Protobuf type resolver to use.
 	Resolver interface {
 		protoregistry.MessageTypeResolver
@@ -75,14 +75,14 @@ type Validator interface {
 	Validate(message proto.Message) error
 }
 
-// CustomUnmarshaller is an interface for custom unmarshaling of Protobuf messages.
-type CustomUnmarshaller interface {
+// CustomUnmarshaler is an interface for custom unmarshaling of Protobuf messages.
+type CustomUnmarshaler interface {
 	// Unmarshal the given node into the given message.
 	//
 	// Returns an error if the node is invalid for the message.
-	// Returns (true, nil) if the node was handled by the custom unmarshaller.
+	// Returns (true, nil) if the node was handled by the custom unmarshaler.
 	// Otherwise, returns (false, nil), to indicate that the node should be
-	// unmarshaled by the default unmarshaller.
+	// unmarshaled by the default unmarshaler.
 	//
 	// When unmarshaling a google.protobuf.Any message, the `@type` field is
 	// included in the node.
@@ -165,7 +165,7 @@ func (o UnmarshalOptions) unmarshalNode(node *yaml.Node, message proto.Message, 
 	if node.Kind == 0 {
 		return nil
 	}
-	unm := &unmarshaller{
+	unm := &unmarshaler{
 		options:   o,
 		validator: o.Validator,
 		lines:     strings.Split(string(data), "\n"),
@@ -207,14 +207,14 @@ type protoResolver interface {
 	protoregistry.ExtensionTypeResolver
 }
 
-type unmarshaller struct {
+type unmarshaler struct {
 	options   UnmarshalOptions
 	errors    []error
 	validator Validator
 	lines     []string
 }
 
-func (u *unmarshaller) addError(node *yaml.Node, err error) {
+func (u *unmarshaler) addError(node *yaml.Node, err error) {
 	u.errors = append(u.errors, &nodeError{
 		Path:  u.options.Path,
 		Node:  node,
@@ -222,11 +222,11 @@ func (u *unmarshaller) addError(node *yaml.Node, err error) {
 		line:  u.lines[node.Line-1],
 	})
 }
-func (u *unmarshaller) addErrorf(node *yaml.Node, format string, args ...interface{}) {
+func (u *unmarshaler) addErrorf(node *yaml.Node, format string, args ...interface{}) {
 	u.addError(node, fmt.Errorf(format, args...))
 }
 
-func (u *unmarshaller) checkKind(node *yaml.Node, expected yaml.Kind) bool {
+func (u *unmarshaler) checkKind(node *yaml.Node, expected yaml.Kind) bool {
 	if node.Kind != expected {
 		u.addErrorf(node, "expected %v, got %v", getNodeKind(expected), getNodeKind(node.Kind))
 		return false
@@ -234,13 +234,13 @@ func (u *unmarshaller) checkKind(node *yaml.Node, expected yaml.Kind) bool {
 	return true
 }
 
-func (u *unmarshaller) checkTag(node *yaml.Node, expected string) {
+func (u *unmarshaler) checkTag(node *yaml.Node, expected string) {
 	if node.Tag != "" && node.Tag != expected {
 		u.addErrorf(node, "expected tag %v, got %v", expected, node.Tag)
 	}
 }
 
-func (u *unmarshaller) findAnyTypeURL(node *yaml.Node) string {
+func (u *unmarshaler) findAnyTypeURL(node *yaml.Node) string {
 	typeURL := ""
 	for i := 1; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i-1]
@@ -253,7 +253,7 @@ func (u *unmarshaller) findAnyTypeURL(node *yaml.Node) string {
 	return typeURL
 }
 
-func (u *unmarshaller) resolveAnyType(typeURL string) (protoreflect.MessageType, error) {
+func (u *unmarshaler) resolveAnyType(typeURL string) (protoreflect.MessageType, error) {
 	// Get the message type.
 	msgType, err := u.getResolver().FindMessageByURL(typeURL)
 	if err != nil {
@@ -262,7 +262,7 @@ func (u *unmarshaller) resolveAnyType(typeURL string) (protoreflect.MessageType,
 	return msgType, nil
 }
 
-func (u *unmarshaller) findAnyType(node *yaml.Node) (protoreflect.MessageType, error) {
+func (u *unmarshaler) findAnyType(node *yaml.Node) (protoreflect.MessageType, error) {
 	typeURL := u.findAnyTypeURL(node)
 	if typeURL == "" {
 		return nil, errors.New("missing @type field")
@@ -272,7 +272,7 @@ func (u *unmarshaller) findAnyType(node *yaml.Node) (protoreflect.MessageType, e
 
 // Unmarshal the field based on the field kind, ignoring IsList and IsMap,
 // which are handled by the caller.
-func (u *unmarshaller) unmarshalScalar(
+func (u *unmarshaler) unmarshalScalar(
 	node *yaml.Node,
 	field protoreflect.FieldDescriptor,
 	forKey bool,
@@ -308,7 +308,7 @@ func (u *unmarshaller) unmarshalScalar(
 }
 
 // Base64 decodes the given node value.
-func (u *unmarshaller) unmarshalBytes(node *yaml.Node) []byte {
+func (u *unmarshaler) unmarshalBytes(node *yaml.Node) []byte {
 	if !u.checkKind(node, yaml.ScalarNode) {
 		return nil
 	}
@@ -330,7 +330,7 @@ func (u *unmarshaller) unmarshalBytes(node *yaml.Node) []byte {
 }
 
 // Unmarshal raw `true` or `false` values, only allowing for strings for keys.
-func (u *unmarshaller) unmarshalBool(node *yaml.Node, forKey bool) bool {
+func (u *unmarshaler) unmarshalBool(node *yaml.Node, forKey bool) bool {
 	if u.checkKind(node, yaml.ScalarNode) {
 		switch node.Value {
 		case "true":
@@ -353,7 +353,7 @@ func (u *unmarshaller) unmarshalBool(node *yaml.Node, forKey bool) bool {
 // Unmarshal the given node into an enum value.
 //
 // Accepts either the enum name or number.
-func (u *unmarshaller) unmarshalEnum(node *yaml.Node, field protoreflect.FieldDescriptor) protoreflect.EnumNumber {
+func (u *unmarshaler) unmarshalEnum(node *yaml.Node, field protoreflect.FieldDescriptor) protoreflect.EnumNumber {
 	u.checkKind(node, yaml.ScalarNode)
 	// Get the enum descriptor.
 	enumDesc := field.Enum()
@@ -384,7 +384,7 @@ func (u *unmarshaller) unmarshalEnum(node *yaml.Node, field protoreflect.FieldDe
 }
 
 // Unmarshal the given node into a float with the given bits.
-func (u *unmarshaller) unmarshalFloat(node *yaml.Node, bits int) float64 {
+func (u *unmarshaler) unmarshalFloat(node *yaml.Node, bits int) float64 {
 	if !u.checkKind(node, yaml.ScalarNode) {
 		return 0
 	}
@@ -397,7 +397,7 @@ func (u *unmarshaller) unmarshalFloat(node *yaml.Node, bits int) float64 {
 }
 
 // Unmarshal the given node into an unsigned integer with the given bits.
-func (u *unmarshaller) unmarshalUnsigned(node *yaml.Node, bits int) uint64 {
+func (u *unmarshaler) unmarshalUnsigned(node *yaml.Node, bits int) uint64 {
 	if !u.checkKind(node, yaml.ScalarNode) {
 		return 0
 	}
@@ -413,7 +413,7 @@ func (u *unmarshaller) unmarshalUnsigned(node *yaml.Node, bits int) uint64 {
 }
 
 // Unmarshal the given node into a signed integer with the given bits.
-func (u *unmarshaller) unmarshalInteger(node *yaml.Node, bits int) int64 {
+func (u *unmarshaler) unmarshalInteger(node *yaml.Node, bits int) int64 {
 	if !u.checkKind(node, yaml.ScalarNode) {
 		return 0
 	}
@@ -537,7 +537,7 @@ func parseIntLiteral(value string) (intLit, error) {
 	return lit, err
 }
 
-func (u *unmarshaller) getResolver() protoResolver {
+func (u *unmarshaler) getResolver() protoResolver {
 	if u.options.Resolver != nil {
 		return u.options.Resolver
 	}
@@ -546,7 +546,7 @@ func (u *unmarshaller) getResolver() protoResolver {
 
 // findField searches for the field with the given 'key' by extension type, JSONName, TextName,
 // and finally by Number.
-func (u *unmarshaller) findField(key string, msgDesc protoreflect.MessageDescriptor) (protoreflect.FieldDescriptor, error) {
+func (u *unmarshaler) findField(key string, msgDesc protoreflect.MessageDescriptor) (protoreflect.FieldDescriptor, error) {
 	fields := msgDesc.Fields()
 	if strings.HasPrefix(key, "[") && strings.HasSuffix(key, "]") {
 		extName := protoreflect.FullName(key[1 : len(key)-1])
@@ -576,7 +576,7 @@ func (u *unmarshaller) findField(key string, msgDesc protoreflect.MessageDescrip
 }
 
 // Unmarshal a field, handling isList/isMap.
-func (u *unmarshaller) unmarshalField(node *yaml.Node, field protoreflect.FieldDescriptor, message proto.Message) {
+func (u *unmarshaler) unmarshalField(node *yaml.Node, field protoreflect.FieldDescriptor, message proto.Message) {
 	if oneofDesc := field.ContainingOneof(); oneofDesc != nil && !oneofDesc.IsSynthetic() {
 		// Check if another field in the oneof is already set.
 		if whichOne := message.ProtoReflect().WhichOneof(oneofDesc); whichOne != nil {
@@ -600,7 +600,7 @@ func (u *unmarshaller) unmarshalField(node *yaml.Node, field protoreflect.FieldD
 }
 
 // Unmarshal the list, with explicit handling for lists of messages.
-func (u *unmarshaller) unmarshalList(node *yaml.Node, field protoreflect.FieldDescriptor, list protoreflect.List) {
+func (u *unmarshaler) unmarshalList(node *yaml.Node, field protoreflect.FieldDescriptor, list protoreflect.List) {
 	if u.checkKind(node, yaml.SequenceNode) {
 		switch field.Kind() {
 		case protoreflect.MessageKind, protoreflect.GroupKind:
@@ -622,7 +622,7 @@ func (u *unmarshaller) unmarshalList(node *yaml.Node, field protoreflect.FieldDe
 }
 
 // Unmarshal the map, with explicit handling for maps to messages.
-func (u *unmarshaller) unmarshalMap(node *yaml.Node, field protoreflect.FieldDescriptor, mapVal protoreflect.Map) {
+func (u *unmarshaler) unmarshalMap(node *yaml.Node, field protoreflect.FieldDescriptor, mapVal protoreflect.Map) {
 	if !u.checkKind(node, yaml.MappingNode) {
 		return
 	}
@@ -654,9 +654,9 @@ func isNull(node *yaml.Node) bool {
 	return node.Tag == "!!null"
 }
 
-// Resolve the node to be used with the custom unmarshaller. Returns nil if the
+// Resolve the node to be used with the custom unmarshaler. Returns nil if the
 // there was an error.
-func (u *unmarshaller) findNodeForCustom(node *yaml.Node, forAny bool) *yaml.Node {
+func (u *unmarshaler) findNodeForCustom(node *yaml.Node, forAny bool) *yaml.Node {
 	if !forAny {
 		return node
 	}
@@ -683,22 +683,22 @@ func (u *unmarshaller) findNodeForCustom(node *yaml.Node, forAny bool) *yaml.Nod
 }
 
 // Unmarshal the given yaml node into the given proto.Message.
-func (u *unmarshaller) unmarshalMessage(node *yaml.Node, message proto.Message, forAny bool) {
-	if u.options.CustomUnmarshaller != nil {
-		if ok, err := u.options.CustomUnmarshaller.Unmarshal(node, message); err != nil {
+func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message, forAny bool) {
+	if u.options.CustomUnmarshaler != nil {
+		if ok, err := u.options.CustomUnmarshaler.Unmarshal(node, message); err != nil {
 			u.addError(node, err)
 			return
 		} else if ok {
-			return // Custom unmarshaller handled the decoding.
+			return // Custom unmarshaler handled the decoding.
 		}
 	}
-	// Check for a custom unmarshaller
-	if custom, ok := wktUnmarshallers[message.ProtoReflect().Descriptor().FullName()]; ok {
+	// Check for a custom unmarshaler
+	if custom, ok := wktUnmarshalers[message.ProtoReflect().Descriptor().FullName()]; ok {
 		valueNode := u.findNodeForCustom(node, forAny)
 		if valueNode == nil {
 			return // Error already added.
 		} else if custom(u, valueNode, message) {
-			return // Custom unmarshaller handled the decoding.
+			return // Custom unmarshaler handled the decoding.
 		}
 	}
 	if isNull(node) {
@@ -712,7 +712,7 @@ func (u *unmarshaller) unmarshalMessage(node *yaml.Node, message proto.Message, 
 	u.unmarshalMessageFields(node, message, forAny)
 }
 
-func (u *unmarshaller) unmarshalMessageFields(node *yaml.Node, message proto.Message, forAny bool) {
+func (u *unmarshaler) unmarshalMessageFields(node *yaml.Node, message proto.Message, forAny bool) {
 	// Decode the fields
 	msgDesc := message.ProtoReflect().Descriptor()
 	for i := 0; i < len(node.Content); i += 2 {
@@ -752,9 +752,9 @@ func (u *unmarshaller) unmarshalMessageFields(node *yaml.Node, message proto.Mes
 	}
 }
 
-type customUnmarshaller func(u *unmarshaller, node *yaml.Node, message proto.Message) bool
+type customUnmarshaler func(u *unmarshaler, node *yaml.Node, message proto.Message) bool
 
-func unmarshalAnyMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalAnyMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	if node.Kind != yaml.MappingNode || len(node.Content) == 0 {
 		return false
 	}
@@ -824,7 +824,7 @@ func setFieldByName(message proto.Message, name string, value protoreflect.Value
 	return true
 }
 
-func unmarshalDurationMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalDurationMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	if node.Kind != yaml.ScalarNode || len(node.Value) == 0 || isNull(node) {
 		return false
 	}
@@ -845,7 +845,7 @@ func unmarshalDurationMsg(unm *unmarshaller, node *yaml.Node, message proto.Mess
 		setFieldByName(message, "nanos", protoreflect.ValueOfInt32(duration.GetNanos()))
 }
 
-func unmarshalTimestampMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalTimestampMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	if node.Kind != yaml.ScalarNode || len(node.Value) == 0 || isNull(node) {
 		return false
 	}
@@ -864,7 +864,7 @@ func unmarshalTimestampMsg(unm *unmarshaller, node *yaml.Node, message proto.Mes
 }
 
 // Forwards unmarshaling to the "value" field of the given wrapper message.
-func unmarshalWrapperMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalWrapperMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	valueField := message.ProtoReflect().Descriptor().Fields().ByName("value")
 	if node.Kind == yaml.MappingNode || valueField == nil {
 		return false
@@ -933,7 +933,7 @@ func dynSetStruct(message proto.Message, structVal *structpb.Struct) bool {
 	return true
 }
 
-func unmarshalValueMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalValueMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	value, ok := message.(*structpb.Value)
 	if !ok {
 		value = &structpb.Value{}
@@ -945,7 +945,7 @@ func unmarshalValueMsg(unm *unmarshaller, node *yaml.Node, message proto.Message
 	return true
 }
 
-func unmarshalListValueMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalListValueMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	if node.Kind != yaml.SequenceNode {
 		return false
 	}
@@ -960,7 +960,7 @@ func unmarshalListValueMsg(unm *unmarshaller, node *yaml.Node, message proto.Mes
 	return true
 }
 
-func unmarshalStructMsg(unm *unmarshaller, node *yaml.Node, message proto.Message) bool {
+func unmarshalStructMsg(unm *unmarshaler, node *yaml.Node, message proto.Message) bool {
 	if node.Kind != yaml.MappingNode {
 		return false
 	}
@@ -977,7 +977,7 @@ func unmarshalStructMsg(unm *unmarshaller, node *yaml.Node, message proto.Messag
 
 // Unmarshal the given yaml node into a structpb.Value, using the given
 // field descriptor to validate the type, if non-nil.
-func (u *unmarshaller) unmarshalValue(
+func (u *unmarshaler) unmarshalValue(
 	node *yaml.Node,
 	value *structpb.Value,
 ) {
@@ -1002,7 +1002,7 @@ func (u *unmarshaller) unmarshalValue(
 
 // Unmarshal the given yaml node into a structpb.ListValue, using the given field
 // descriptor to validate each item, if non-nil.
-func (u *unmarshaller) unmarshalListValue(
+func (u *unmarshaler) unmarshalListValue(
 	node *yaml.Node,
 	list *structpb.ListValue,
 ) {
@@ -1018,7 +1018,7 @@ func (u *unmarshaller) unmarshalListValue(
 // Structs can represent either a message or a map.
 // For messages, the message descriptor can be provided or inferred from the node.
 // For maps, the field descriptor can be provided to validate the map keys/values.
-func (u *unmarshaller) unmarshalStruct(
+func (u *unmarshaler) unmarshalStruct(
 	node *yaml.Node,
 	message *structpb.Struct,
 ) {
@@ -1040,7 +1040,7 @@ func (u *unmarshaller) unmarshalStruct(
 	}
 }
 
-func (u *unmarshaller) unmarshalScalarValue(node *yaml.Node, value *structpb.Value) {
+func (u *unmarshaler) unmarshalScalarValue(node *yaml.Node, value *structpb.Value) {
 	switch node.Tag {
 	case "!!null":
 		value.Kind = &structpb.Value_NullValue{}
@@ -1052,7 +1052,7 @@ func (u *unmarshaller) unmarshalScalarValue(node *yaml.Node, value *structpb.Val
 }
 
 // bool, string, or bytes.
-func (u *unmarshaller) unmarshalScalarBool(node *yaml.Node, value *structpb.Value) {
+func (u *unmarshaler) unmarshalScalarBool(node *yaml.Node, value *structpb.Value) {
 	switch node.Value {
 	case "true":
 		value.Kind = &structpb.Value_BoolValue{BoolValue: true}
@@ -1064,7 +1064,7 @@ func (u *unmarshaller) unmarshalScalarBool(node *yaml.Node, value *structpb.Valu
 }
 
 // Can be string, bytes, float, or int.
-func (u *unmarshaller) unmarshalScalarString(node *yaml.Node, value *structpb.Value) {
+func (u *unmarshaler) unmarshalScalarString(node *yaml.Node, value *structpb.Value) {
 	if node.Tag == "!!str" {
 		// Explicitly tagged string.
 		value.Kind = &structpb.Value_StringValue{StringValue: node.Value}
@@ -1087,7 +1087,7 @@ func (u *unmarshaller) unmarshalScalarString(node *yaml.Node, value *structpb.Va
 	u.unmarshalScalarFloat(node, value, floatVal)
 }
 
-func (u *unmarshaller) unmarshalScalarFloat(node *yaml.Node, value *structpb.Value, floatVal float64) {
+func (u *unmarshaler) unmarshalScalarFloat(node *yaml.Node, value *structpb.Value, floatVal float64) {
 	// Try to parse it as in integer, to see if the float representation is lossy.
 	lit, litErr := parseIntLiteral(node.Value)
 
@@ -1109,7 +1109,7 @@ func (u *unmarshaller) unmarshalScalarFloat(node *yaml.Node, value *structpb.Val
 //   - 'foo[0]' -> the first element of the repeated field foo or the map entry with key '0'
 //   - 'foo.bar' -> the field bar in the message field foo
 //   - 'foo["bar"]' -> the map entry with key 'bar' in the map field foo
-func (u *unmarshaller) nodeClosestToPath(root *yaml.Node, msgDesc protoreflect.MessageDescriptor, path string, toKey bool) *yaml.Node {
+func (u *unmarshaler) nodeClosestToPath(root *yaml.Node, msgDesc protoreflect.MessageDescriptor, path string, toKey bool) *yaml.Node {
 	parsedPath, err := parseFieldPath(path)
 	if err != nil {
 		return root
@@ -1179,7 +1179,7 @@ func parseNextValue(path string) (string, string) {
 }
 
 // Returns the node as close to the given path as possible.
-func (u *unmarshaller) findNodeByPath(root *yaml.Node, msgDesc protoreflect.MessageDescriptor, path []string, toKey bool) *yaml.Node {
+func (u *unmarshaler) findNodeByPath(root *yaml.Node, msgDesc protoreflect.MessageDescriptor, path []string, toKey bool) *yaml.Node {
 	cur := root
 	curMsg := msgDesc
 	var curMap protoreflect.FieldDescriptor
@@ -1382,7 +1382,7 @@ func leadingInt(str string) (result uint64, rem string, pre bool, err error) {
 }
 
 func init() { //nolint:gochecknoinits
-	wktUnmarshallers = map[protoreflect.FullName]customUnmarshaller{
+	wktUnmarshalers = map[protoreflect.FullName]customUnmarshaler{
 		"google.protobuf.Any":         unmarshalAnyMsg,
 		"google.protobuf.Duration":    unmarshalDurationMsg,
 		"google.protobuf.Timestamp":   unmarshalTimestampMsg,

--- a/decode_test.go
+++ b/decode_test.go
@@ -30,31 +30,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type testCustomUnmarshaler struct{}
+type testCustomUnmarshaller struct{}
 
-var _ CustomUnmarshaler = (*testCustomUnmarshaler)(nil)
+var _ CustomUnmarshaller = (*testCustomUnmarshaller)(nil)
 
-func (t *testCustomUnmarshaler) Unmarshal(node *yaml.Node, msg proto.Message) (bool, error) {
+func (t *testCustomUnmarshaller) Unmarshal(node *yaml.Node, msg proto.Message) (bool, error) {
 	if node.Kind != yaml.ScalarNode {
 		return false, nil
 	}
-	ts, ok := msg.(*timestamppb.Timestamp)
+	protoTs, ok := msg.(*timestamppb.Timestamp)
 	if !ok {
 		return false, nil
 	}
 
 	switch strings.ToLower(node.Value) {
 	case "epoch":
-		proto.Reset(ts)
+		proto.Reset(protoTs)
 		return true, nil
 	case "now":
-		proto.Merge(ts, timestamppb.Now())
+		proto.Merge(protoTs, timestamppb.Now())
 		return true, nil
 	case "tomorrow":
-		proto.Merge(ts, timestamppb.New(time.Now().Add(24*time.Hour)))
+		proto.Merge(protoTs, timestamppb.New(time.Now().Add(24*time.Hour)))
 		return true, nil
 	case "yesterday":
-		proto.Merge(ts, timestamppb.New(time.Now().Add(-24*time.Hour)))
+		proto.Merge(protoTs, timestamppb.New(time.Now().Add(-24*time.Hour)))
 		return true, nil
 	}
 	return false, nil
@@ -63,7 +63,7 @@ func (t *testCustomUnmarshaler) Unmarshal(node *yaml.Node, msg proto.Message) (b
 func TestCustomUnmarshal(t *testing.T) {
 	t.Parallel()
 	options := UnmarshalOptions{
-		CustomUnmarshaler: &testCustomUnmarshaler{},
+		CustomUnmarshaller: &testCustomUnmarshaller{},
 	}
 	for _, testCase := range []struct {
 		Input string

--- a/decode_test.go
+++ b/decode_test.go
@@ -30,11 +30,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type testCustomUnmarshaller struct{}
+type testCustomUnmarshaler struct{}
 
-var _ CustomUnmarshaller = (*testCustomUnmarshaller)(nil)
+var _ CustomUnmarshaler = (*testCustomUnmarshaler)(nil)
 
-func (t *testCustomUnmarshaller) Unmarshal(node *yaml.Node, msg proto.Message) (bool, error) {
+func (t *testCustomUnmarshaler) Unmarshal(node *yaml.Node, msg proto.Message) (bool, error) {
 	if node.Kind != yaml.ScalarNode {
 		return false, nil
 	}
@@ -63,7 +63,7 @@ func (t *testCustomUnmarshaller) Unmarshal(node *yaml.Node, msg proto.Message) (
 func TestCustomUnmarshal(t *testing.T) {
 	t.Parallel()
 	options := UnmarshalOptions{
-		CustomUnmarshaller: &testCustomUnmarshaller{},
+		CustomUnmarshaler: &testCustomUnmarshaler{},
 	}
 	for _, testCase := range []struct {
 		Input string

--- a/decode_test.go
+++ b/decode_test.go
@@ -47,7 +47,7 @@ func (t *testCustomUnmarshaller) Unmarshal(node *yaml.Node, msg proto.Message) (
 	case "epoch":
 		proto.Reset(protoTs)
 		return true, nil
-	case "now":
+	case "today":
 		proto.Merge(protoTs, timestamppb.Now())
 		return true, nil
 	case "tomorrow":
@@ -70,7 +70,7 @@ func TestCustomUnmarshal(t *testing.T) {
 		Time  time.Time
 	}{
 		{Input: "epoch", Time: time.UnixMicro(0)},
-		{Input: "now", Time: time.Now()},
+		{Input: "today", Time: time.Now()},
 		{Input: "tomorrow", Time: time.Now().Add(24 * time.Hour)},
 		{Input: "yesterday", Time: time.Now().Add(-24 * time.Hour)},
 		{Input: "2023-10-01T00:00:00Z", Time: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)},
@@ -81,7 +81,7 @@ func TestCustomUnmarshal(t *testing.T) {
 			err := options.Unmarshal([]byte(testCase.Input), actual)
 			require.NoError(t, err)
 			delta := actual.AsTime().Sub(testCase.Time)
-			assert.LessOrEqual(t, delta.Seconds(), 10.0)
+			assert.LessOrEqual(t, delta, 1*time.Hour)
 		})
 	}
 }


### PR DESCRIPTION
This allows specific messages, for example https://buf.build/aep/type/docs/main:aep.type#aep.type.Money, to support custom unmarshaling, just like a built-in well-known type.