### PR TITLE
Remove yaml.Node from the public interface

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -77,19 +77,19 @@ type Validator interface {
 
 // CustomUnmarshaler is an interface for custom unmarshaling of Protobuf messages.
 type CustomUnmarshaler interface {
-	// Unmarshal the given node into the given message.
+	// Unmarshal the given string into the given message.
 	//
-	// Returns an error if the node is invalid for the message.
-	// Returns (true, nil) if the node was handled by the custom unmarshaler.
-	// Otherwise, returns (false, nil), to indicate that the node should be
-	// unmarshaled by the default unmarshaler.
+	// Returns an error if the string is invalid for the message.
+	// Returns (true, nil) if unmarshaling was successful.
+	// Otherwise, returns (false, nil), to indicate that the default unmarshaler
+	// should be used.
 	//
 	// When unmarshaling a google.protobuf.Any message, the `@type` field is
 	// included in the node.
 	//
 	// The 'message' argument maybe [dynamicpb.Message] or a concrete message type
 	// depending on the [UnmarshalOptions].Resolver used.
-	Unmarshal(node *yaml.Node, message proto.Message) (bool, error)
+	Unmarshal(value string, message proto.Message) (bool, error)
 }
 
 // Unmarshal a Protobuf message from the given YAML data.
@@ -709,8 +709,8 @@ func (u *unmarshaler) findNodeForCustom(node *yaml.Node, forAny bool) *yaml.Node
 
 // Unmarshal the given yaml node into the given proto.Message.
 func (u *unmarshaler) unmarshalMessage(node *yaml.Node, message proto.Message, forAny bool) {
-	if u.options.CustomUnmarshaler != nil {
-		if ok, err := u.options.CustomUnmarshaler.Unmarshal(node, message); err != nil {
+	if u.options.CustomUnmarshaler != nil && node.Kind == yaml.ScalarNode {
+		if ok, err := u.options.CustomUnmarshaler.Unmarshal(node.Value, message); err != nil {
 			u.addError(node, err)
 			return
 		} else if ok {

--- a/decode_test.go
+++ b/decode_test.go
@@ -27,23 +27,19 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v3"
 )
 
 type testCustomUnmarshaler struct{}
 
 var _ CustomUnmarshaler = (*testCustomUnmarshaler)(nil)
 
-func (t *testCustomUnmarshaler) Unmarshal(node *yaml.Node, msg proto.Message) (bool, error) {
-	if node.Kind != yaml.ScalarNode {
-		return false, nil
-	}
+func (t *testCustomUnmarshaler) Unmarshal(value string, msg proto.Message) (bool, error) {
 	protoTs, ok := msg.(*timestamppb.Timestamp)
 	if !ok {
 		return false, nil
 	}
 
-	switch strings.ToLower(node.Value) {
+	switch strings.ToLower(value) {
 	case "epoch":
 		proto.Reset(protoTs)
 		return true, nil


### PR DESCRIPTION
As the repo is now read-only, we might want to switch in the future.