### PR TITLE
Migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,8 +37,8 @@ linters:
             - github.com/bufbuild/protoyaml-go/decode
             - buf.build/gen/go/bufbuild/protovalidate
             - buf.build/go/protovalidate
+            - go.yaml.in/yaml/v3
             - google.golang.org/protobuf
-            - gopkg.in/yaml.v3
     errcheck:
       check-type-assertions: true
     forbidigo:

--- a/decode.go
+++ b/decode.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"buf.build/go/protovalidate"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -32,7 +33,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/decode_test.go
+++ b/decode_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v3"
 )
 
 type testCustomUnmarshaler struct{}

--- a/encode.go
+++ b/encode.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"gopkg.in/yaml.v3"
 )
 
 // Marshal marshals the given message to YAML.

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ import (
 
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	"buf.build/go/protovalidate"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // nodeError is an error that occurred while processing a specific yaml.Node.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	buf.build/go/protovalidate v0.11.0
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
+	go.yaml.in/yaml/v3 v3.0.4
 	google.golang.org/protobuf v1.36.6
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -22,4 +22,5 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 h1:aAcj0Da7eBAtrTp03QXWvm88pSyOt+UgdZw2BFZ+lEw=
 golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=

--- a/protoyaml_test.go
+++ b/protoyaml_test.go
@@ -24,6 +24,7 @@ import (
 	"buf.build/go/protoyaml/internal/protoyamltest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -32,7 +33,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v3"
 )
 
 func TestParseFieldPath(t *testing.T) {
@@ -203,7 +203,7 @@ func TestYamlNewLineMaps(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Should be `"\n": "\n"`, but its garbled.
-	if string(data) != "? |4+\n: |4+\n" {
+	if string(data) != "? |4+\n\n: |4+\n\n" {
 		t.Fatalf("Expected garbled output, got %s", string(data))
 	}
 }


### PR DESCRIPTION
gopkg.in/yaml.v3 is unmaintained, ref
https://github.com/yaml/go-yaml#project-status

Upgrade to 3.0.4 while at it.

3.0.1...3.0.2 diff (3.0.1 are identical):
https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd

3.0.2...3.0.4 diff:
https://github.com/yaml/go-yaml/compare/v3.0.2...v3.0.4