### PR TITLE
Do not materialize message fields set to null

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -616,6 +616,9 @@ func (u *unmarshaler) unmarshalField(node *yaml.Node, field protoreflect.FieldDe
 	case field.IsMap():
 		u.unmarshalMap(node, field, message.ProtoReflect().Mutable(field).Map())
 	case field.Message() != nil:
+		if isNull(node) && field.Message().FullName() != "google.protobuf.Value" {
+			return // Null clears a message field.
+		}
 		u.unmarshalMessage(node, message.ProtoReflect().Mutable(field).Message().Interface(), false)
 	default:
 		if val, ok := u.unmarshalScalar(node, field, false); ok {

--- a/protoyaml_test.go
+++ b/protoyaml_test.go
@@ -234,6 +234,24 @@ func TestNullValueEnum(t *testing.T) {
 	}
 }
 
+func TestNullMessageField(t *testing.T) {
+	t.Parallel()
+	actual := &proto3.TestAllTypes{}
+	if err := Unmarshal([]byte("singleTimestamp: null\n"), actual); err != nil {
+		t.Fatal(err)
+	}
+	if actual.GetSingleTimestamp() != nil {
+		t.Fatalf("Expected nil, got %v", actual.GetSingleTimestamp())
+	}
+	expected := &proto3.TestAllTypes{}
+	if err := protojson.Unmarshal([]byte(`{"singleTimestamp": null}`), expected); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expected, actual, protocmp.Transform()); diff != "" {
+		t.Fatalf("unexpected diff:\n%s", diff)
+	}
+}
+
 func TestInfNanIntegers(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range []string{


### PR DESCRIPTION
`Unmarshal` was calling `Mutable` on message-kind fields before checking the node, so a `null` value left an empty message instead of clearing the field, diverging from `protojson`. This skips materializing the field for `null` (except `google.protobuf.Value`, where `null` is a value). Closes #55.